### PR TITLE
For upstream fixes

### DIFF
--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -35,8 +35,6 @@
 
 #include "pixmaps/logo.xpm"
 
-static GtkWidget *about = NULL;
-
 void
 oregano_error (gchar *msg)
 {
@@ -139,6 +137,7 @@ oregano_question (gchar *msg)
 void
 dialog_about (void)
 {
+	static GtkWidget *about = NULL;
 	GdkPixbuf *logo;
 
 	const gchar *authors[] = {


### PR DESCRIPTION
The 'about' box could be opened only once. These two commits:
- fix the issue by clearing about after gtk_widget_destroy()
- Change the global var into a local static var.
