### PR TITLE
Issue170

### DIFF
--- a/src/engines/netlist-helper.c
+++ b/src/engines/netlist-helper.c
@@ -353,8 +353,8 @@ void update_schematic(Schematic *sm) {
 			Part *part = iter->data;
 			update_connection_designators(part, part_get_property_ref(part, "template"), &node_ctr);
 		}
-		schematic_set_version(sm, VERSION);
 	}
+	schematic_set_version(sm, VERSION);
 
 	return;
 }

--- a/src/model/part-property.h
+++ b/src/model/part-property.h
@@ -41,17 +41,6 @@ typedef struct
 	gchar *value;
 } PartProperty;
 
-typedef enum {
-	CONVERT_PARSE_START,
-	CONVERT_PARSE_PERCENT,
-	CONVERT_PARSE_AT,
-	CONVERT_PARSE_AMPERSAND,
-	CONVERT_PARSE_QUESTION_MARK,
-	CONVERT_PARSE_TILDE,
-	CONVERT_PARSE_HASHTAG,
-	CONVERT_PARSE_FINISH
-} State_convert;
-
 void update_connection_designators (Part *part, char **prop, int *node_ctr);
 gchar *part_property_expand_macros (Part *part, gchar *string);
 

--- a/wscript
+++ b/wscript
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 # encoding: utf-8
 
-VERSION = '0.84.0'
+VERSION = '0.84.1'
 APPNAME = 'oregano'
 
 top = '.'


### PR DESCRIPTION
The solution was pretty simple: change %f to %e in the printf command. The other stuff is

- warning elimination and
- a proposal for better ngspice error handling: instead of printing the solution as far as possible, the ngspice output file will be printed in the log view instead, if ngspice ends the simulation in the middle of nowhere.
- increase the third number of Oregano VERSION because of this bugfix