### PR TITLE
plot: adaptive axis number precision, fixed transformation bugs, reset view feature, closes #172

### DIFF
--- a/docs/Oregano-Plot-HOWTO.md
+++ b/docs/Oregano-Plot-HOWTO.md
@@ -1,0 +1,52 @@
+Oregano - Plot
+==============
+
+
+Start
+-----
+
+The Oregano - Plot is started automatically after you hit
+"Run a simulation" (F5) and the netlist has been created successfully
+and ngspice simulation has completed successfully.
+
+
+Plot
+----
+
+There are 2 options how the black screen can be filled with functions.
+
+1. **Nodes**<br>
+Electical potentials existing at the defined voltage clamps can be
+plotted by opening the "Nodes"-tree and checking the checkboxes.
+2. **Functions**<br>
+If you want to plot something like voltage between two potentials,
+you can do this by defining a "Substraction"-Function by clicking
+at "File"->"Add Function" in the menubar. The dialog is pretty intuitive.
+After adding the function by cklicking on the "Add"-buttion, the
+new function is appearing in the "Function"-tree and can be plotted
+by activating the checkbox.
+
+
+Zoom in
+-------
+
+Zooming in is supported by defining a "positive" zoom rectangle. The
+upper left corner of the rectangle is defined by clicking and holding
+the left mouse button. The lower right corner of the rectangle is defined
+by moving the mouse (while holding the left mouse button) to the lower
+right corner and releasing the left mouse button there.
+
+
+Zoom out
+--------
+
+You can zoom out by resetting the view.
+
+
+Resetting the view
+------------------
+
+You can reset the view by defining a "negative" zoom rectangle
+(see also "Zoom in").
+
+

--- a/src/gplot/gplot.c
+++ b/src/gplot/gplot.c
@@ -70,8 +70,8 @@ struct _GPlotPriv
 	gdouble zoom;
 	gdouble offset_x;
 	gdouble offset_y;
-	gdouble last_x;
-	gdouble last_y;
+	gdouble press_x;
+	gdouble press_y;
 
 	// Window->Viewport * Transformation Matrix
 	cairo_matrix_t matrix;

--- a/src/model/schematic.c
+++ b/src/model/schematic.c
@@ -492,7 +492,7 @@ void schematic_log_append_error (Schematic *schematic, const char *message)
 
 	priv = schematic->priv;
 
-	log_append (schematic->priv->logstore, "Schematic Error", message);
+	log_append (schematic->priv->logstore, "ngspice Error", message);
 
 	// LEGACY
 	gtk_text_buffer_get_end_iter (priv->log, &iter);

--- a/src/plot.c
+++ b/src/plot.c
@@ -384,10 +384,12 @@ static GtkWidget *plot_window_create (Plot *plot)
 
 	// Creation of the menu
 	menu = gtk_menu_new ();
+	//add Add Function menuitem
 	menuitem = gtk_menu_item_new_with_label (_ ("Add Function"));
 	gtk_menu_shell_append (GTK_MENU_SHELL (menu), menuitem);
 	g_signal_connect (menuitem, "activate", G_CALLBACK (add_function), plot);
 	gtk_widget_show (menuitem);
+	//add separator
 	menuitem = gtk_separator_menu_item_new ();
 	gtk_menu_shell_append (GTK_MENU_SHELL (menu), menuitem);
 	gtk_widget_show (menuitem);

--- a/wscript
+++ b/wscript
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 # encoding: utf-8
 
-VERSION = '0.84.1'
+VERSION = '0.84.2'
 APPNAME = 'oregano'
 
 top = '.'


### PR DESCRIPTION
What's new:

- adaptive precision at x and y axis
- x tick labels are rotating (like in Microsoft Excel), if numbers grow too large
- several small transformation bugs resolved (x,y-zero marker lines moved, functions moved, zoom-box moved)
- reset zoom if zoom-rectangle is "negative"
- increment third version number because of small bugfixes