### PR TITLE
ngspice-analysis: added measuring current feature, closes #176

### DIFF
--- a/data/xml/sim-settings.ui
+++ b/data/xml/sim-settings.ui
@@ -100,30 +100,35 @@
                                 <property name="can_focus">False</property>
                                 <property name="orientation">vertical</property>
                                 <child>
-                                  <object class="GtkBox" id="hbox9">
+                                  <object class="GtkCheckButton" id="trans_init_cond">
+                                    <property name="label" translatable="yes">Use Initial Conditions</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <child>
-                                      <object class="GtkCheckButton" id="trans_init_cond">
-                                        <property name="label" translatable="yes">Use Initial Conditions</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="xalign">0.5</property>
-                                        <property name="draw_indicator">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="use_underline">True</property>
+                                    <property name="xalign">0.5</property>
+                                    <property name="draw_indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">False</property>
                                     <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="trans_analyze_all">
+                                    <property name="label" translatable="yes">Analyze All Currents And Potentials (only ngspice)</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="use_underline">True</property>
+                                    <property name="xalign">0.5</property>
+                                    <property name="draw_indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="position">1</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -208,7 +213,7 @@
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">False</property>
-                                    <property name="position">1</property>
+                                    <property name="position">2</property>
                                   </packing>
                                 </child>
                               </object>

--- a/docs/Simulation-Settings-HOWTO.md
+++ b/docs/Simulation-Settings-HOWTO.md
@@ -1,0 +1,53 @@
+Simulation Settings
+===================
+
+
+Why simulation settings?
+------------------------
+
+Before you can start a simulation, you have to tell the simulation engine
+(ngspice or gnucap) things like
+
+- type of simulation (time domain, frequency domain, DC sweep, ...)
+- simulation dependant parameters (for time domain: start, stop, step, ...)
+- ...
+
+
+How to open the dialog
+----------------------
+
+1. Option: Click the gearwheel "Edit the simulation settings" in the toolbar.
+Don't confuse the single gearwheel button with the three gearwheel button
+("Run a simulation").
+2. Option: Click "Edit"->"Simulation Settings..." in the menubar.
+
+
+Analysis Parameters
+-------------------
+
+**Transient** (time domain)
+
+- Use Initial Conditions:
+	for some parts you can define the initial state of the part, for example
+	the initial current of an inductor or the initial voltage of a capacitor
+- Analyze All Currents And Potentials:
+	The voltage markers will have no effect. As much as possible voltages and currents
+	will be recorded and displayed. THIS FEATURE IS CURRENTLY WORKING ONLY WITH
+	NGSPICE AS SIMULATION ENGINE.
+- Start:
+	Start time from which the data should be recorded.
+- Stop:
+	simulation end time
+- Step:
+	Maximum time step size. If set correctly, it can be a good hint for the simulation
+	engine and the simulation will run fluently and without errors.
+
+
+**Fourier**
+
+//TODO
+
+
+**DC Sweep**
+
+//TODO

--- a/src/load-schematic.c
+++ b/src/load-schematic.c
@@ -65,6 +65,7 @@ typedef enum {
 	PARSE_TRANSIENT_STEP,
 	PARSE_TRANSIENT_STEP_ENABLE,
 	PARSE_TRANSIENT_INIT_COND,
+	PARSE_TRANSIENT_ANALYZE_ALL,
 
 	PARSE_AC_SETTINGS,
 	PARSE_AC_ENABLED,
@@ -386,6 +387,9 @@ static void start_element (ParseState *state, const xmlChar *name, const xmlChar
 		} else if (!xmlStrcmp (BAD_CAST name, BAD_CAST "ogo:init-conditions")) {
 			state->state = PARSE_TRANSIENT_INIT_COND;
 			g_string_truncate (state->content, 0);
+		} else if (!xmlStrcmp (BAD_CAST name, BAD_CAST "ogo:analyze-all")) {
+			state->state = PARSE_TRANSIENT_ANALYZE_ALL;
+			g_string_truncate (state->content, 0);
 		} else {
 			state->prev_state = state->state;
 			state->state = PARSE_UNKNOWN;
@@ -669,6 +673,8 @@ static void start_element (ParseState *state, const xmlChar *name, const xmlChar
 	case PARSE_AUTHOR:
 	case PARSE_VERSION:
 	case PARSE_COMMENTS:
+	case PARSE_TRANSIENT_INIT_COND:
+	case PARSE_TRANSIENT_ANALYZE_ALL:
 		// there should be no tags inside these types of tags
 		g_message ("*** '%s' tag found", name);
 		state->prev_state = state->state;
@@ -684,8 +690,6 @@ static void start_element (ParseState *state, const xmlChar *name, const xmlChar
 	case PARSE_FINISH:
 		// should not start new elements in this state
 		g_assert_not_reached ();
-		break;
-	case PARSE_TRANSIENT_INIT_COND:
 		break;
 	}
 	// g_message("Start element %s (state %s)", name, states[state->state]);
@@ -761,6 +765,11 @@ static void end_element (ParseState *state, const xmlChar *name)
 		                                  !g_ascii_strcasecmp (state->content->str, "true"));
 		state->state = PARSE_TRANSIENT_SETTINGS;
 		break;
+	case PARSE_TRANSIENT_ANALYZE_ALL:
+		sim_settings_set_trans_analyze_all(state->sim_settings,
+		                                !g_ascii_strcasecmp (state->content->str, "true"));
+		state->state = PARSE_TRANSIENT_SETTINGS;
+		break;
 
 	case PARSE_AC_SETTINGS:
 		state->state = PARSE_SIMULATION_SETTINGS;
@@ -769,9 +778,11 @@ static void end_element (ParseState *state, const xmlChar *name)
 		sim_settings_set_ac (state->sim_settings,
 		                     !g_ascii_strcasecmp (state->content->str, "true"));
 		state->state = PARSE_AC_SETTINGS;
+		//FIXME: no break? If really no break, leave a comment here and tell my, why!
 	case PARSE_AC_NPOINTS:
 		sim_settings_set_ac_npoints (state->sim_settings, state->content->str);
 		state->state = PARSE_AC_SETTINGS;
+		//FIXME: no break? If really no break, leave a comment here and tell my, why!
 	case PARSE_AC_START:
 		sim_settings_set_ac_start (state->sim_settings, state->content->str);
 		state->state = PARSE_AC_SETTINGS;
@@ -788,9 +799,11 @@ static void end_element (ParseState *state, const xmlChar *name)
 		sim_settings_set_dc (state->sim_settings,
 		                     !g_ascii_strcasecmp (state->content->str, "true"));
 		state->state = PARSE_DC_SETTINGS;
+		//FIXME: no break? If really no break, leave a comment here and tell my, why!
 	case PARSE_DC_VSRC:
 		sim_settings_set_dc_vsrc (state->sim_settings, state->content->str);
 		state->state = PARSE_DC_SETTINGS;
+		//FIXME: no break? If really no break, leave a comment here and tell my, why!
 	case PARSE_DC_START:
 		sim_settings_set_dc_start (state->sim_settings, state->content->str);
 		state->state = PARSE_DC_SETTINGS;

--- a/src/plot.c
+++ b/src/plot.c
@@ -285,18 +285,19 @@ static void analysis_selected (GtkWidget *combo_box, Plot *plot)
 		GtkTreeIter iter;
 		GPlotFunction *f;
 		if (plot->current->type != DC_TRANSFER) {
-			if (strchr (plot->current->var_names[i], '#') == NULL) {
-				gchar *color;
+			//FIXME extra axis scaling for current/voltage
+			//FIXME or extra plot window for current/voltage
+			//FIXME or extra analysis for current/voltage
+			gchar *color;
 
-				f = create_plot_function_from_simulation_data (i, plot->current);
-				g_object_set (G_OBJECT (f), "visible", FALSE, NULL);
-				g_object_get (G_OBJECT (f), "color", &color, NULL);
+			f = create_plot_function_from_simulation_data (i, plot->current);
+			g_object_set (G_OBJECT (f), "visible", FALSE, NULL);
+			g_object_get (G_OBJECT (f), "color", &color, NULL);
 
-				g_plot_add_function (GPLOT (plot->plot), f);
-				gtk_tree_store_append (GTK_TREE_STORE (model), &iter, &parent_nodes);
-				gtk_tree_store_set (GTK_TREE_STORE (model), &iter, 0, FALSE, 1,
-				                    plot->current->var_names[i], 2, TRUE, 3, color, 4, f, -1);
-			}
+			g_plot_add_function (GPLOT (plot->plot), f);
+			gtk_tree_store_append (GTK_TREE_STORE (model), &iter, &parent_nodes);
+			gtk_tree_store_set (GTK_TREE_STORE (model), &iter, 0, FALSE, 1,
+			                    plot->current->var_names[i], 2, TRUE, 3, color, 4, f, -1);
 		} else {
 			gchar *color;
 

--- a/src/save-schematic.c
+++ b/src/save-schematic.c
@@ -115,6 +115,12 @@ static void write_xml_sim_settings (xmlNodePtr cur, parseXmlContext *ctxt, Schem
 		str = "false";
 	child = xmlNewChild (analysis, ctxt->ns, BAD_CAST "init-conditions", BAD_CAST str);
 
+	if (sim_settings_get_trans_analyze_all(s))
+		str = "true";
+	else
+		str = "false";
+	child = xmlNewChild (analysis, ctxt->ns, BAD_CAST "analyze-all", BAD_CAST str);
+
 	//  AC analysis
 	analysis = xmlNewChild (sim_settings_node, ctxt->ns, BAD_CAST "ac", NULL);
 	if (!analysis) {

--- a/src/sim-settings.c
+++ b/src/sim-settings.c
@@ -57,9 +57,9 @@ struct _SimSettingsPriv
 	          *w_trans_stop;
 	GtkWidget *w_trans_step,
 	          *w_trans_step_enable,
-			  *w_trans_init_cond,
-			  *w_trans_analyze_all,
-			  *w_trans_frame;
+	          *w_trans_init_cond,
+	          *w_trans_analyze_all,
+	          *w_trans_frame;
 	gboolean trans_enable;
 	gboolean trans_init_cond;
 	gboolean trans_analyze_all;

--- a/src/sim-settings.c
+++ b/src/sim-settings.c
@@ -52,10 +52,17 @@ struct _SimSettingsPriv
 {
 	// Transient analysis.
 	GtkWidget *w_main;
-	GtkWidget *w_trans_enable, *w_trans_start, *w_trans_stop;
-	GtkWidget *w_trans_step, *w_trans_step_enable, *w_trans_init_cond, *w_trans_frame;
+	GtkWidget *w_trans_enable, 
+	          *w_trans_start,
+	          *w_trans_stop;
+	GtkWidget *w_trans_step,
+	          *w_trans_step_enable,
+			  *w_trans_init_cond,
+			  *w_trans_analyze_all,
+			  *w_trans_frame;
 	gboolean trans_enable;
 	gboolean trans_init_cond;
+	gboolean trans_analyze_all;
 	gchar *trans_start;
 	gchar *trans_stop;
 	gchar *trans_step;
@@ -343,7 +350,7 @@ static void add_option (GtkWidget *w, SimSettings *s)
 	GtkEntry *entry;
 	GtkWidget *dialog = gtk_dialog_new_with_buttons (
 	    _ ("Add new option"), NULL, GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
-	    GTK_STOCK_CANCEL, GTK_RESPONSE_REJECT, GTK_STOCK_OK, GTK_RESPONSE_OK, NULL);
+	    "_Cancel", GTK_RESPONSE_REJECT, "_OK", GTK_RESPONSE_OK, NULL);
 
 	entry = GTK_ENTRY (gtk_entry_new ());
 	gtk_container_add (GTK_CONTAINER (gtk_dialog_get_content_area (GTK_DIALOG (dialog))),
@@ -485,6 +492,11 @@ gboolean sim_settings_get_trans_init_cond (SimSettings *sim_settings)
 	return sim_settings->priv->trans_init_cond;
 }
 
+gboolean sim_settings_get_trans_analyze_all (SimSettings *sim_settings)
+{
+	return sim_settings->priv->trans_analyze_all;
+}
+
 gdouble sim_settings_get_trans_start (SimSettings *sim_settings)
 {
 	gchar *text = sim_settings->priv->trans_start;
@@ -523,6 +535,11 @@ void sim_settings_set_trans_start (SimSettings *sim_settings, gchar *str)
 void sim_settings_set_trans_init_cond (SimSettings *sim_settings, gboolean enable)
 {
 	sim_settings->priv->trans_init_cond = enable;
+}
+
+void sim_settings_set_trans_analyze_all (SimSettings *sim_settings, gboolean enable)
+{
+	sim_settings->priv->trans_analyze_all = enable;
 }
 
 void sim_settings_set_trans_stop (SimSettings *sim_settings, gchar *str)
@@ -760,6 +777,9 @@ static void response_callback (GtkButton *button, Schematic *sm)
 	priv->trans_init_cond =
 	    gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (priv->w_trans_init_cond));
 
+	priv->trans_analyze_all =
+	    gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (priv->w_trans_analyze_all));
+
 	// DC
 	priv->dc_enable = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (priv->w_dc_enable));
 	if (priv->dc_vin)
@@ -987,10 +1007,25 @@ void sim_settings_show (GtkWidget *widget, SchematicView *sv)
 	g_signal_connect (G_OBJECT (w), "toggled", G_CALLBACK (trans_step_enable_cb), s);
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (w), priv->trans_step_enable);
 
-	// FIXME this does do nothing!
+	// get the gui element
 	w = GTK_WIDGET (gtk_builder_get_object (builder, "trans_init_cond"));
+	// save the gui element to struct
 	priv->w_trans_init_cond = w;
+	// Set checkbox enabled, if trans_init_cond equal true.
+	// trans_init_cond could be set to true because
+	// - user opened the settings dialog some seconds ago and has set the checkbox
+	// - user opened old file in which there was set the checkbox state to true
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (w), priv->trans_init_cond);
+
+	// get the gui element
+	w = GTK_WIDGET (gtk_builder_get_object (builder, "trans_analyze_all"));
+	// save the gui element to struct
+	priv->w_trans_analyze_all = w;
+	// Set checkbox enabled, if trans_analyze_all equal true.
+	// trans_init_cond could be set to true because
+	// - user opened the settings dialog some seconds ago and has set the checkbox
+	// - user opened old file in which there was set the checkbox state to true
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (w), priv->trans_analyze_all);
 
 	// AC  //
 	// *** //

--- a/src/simulation.h
+++ b/src/simulation.h
@@ -73,7 +73,6 @@ typedef struct _SimulationFunction
 struct _SimulationData
 {
 	AnalysisType type;
-	gint state;
 	gint n_variables;
 	gchar **var_names;
 	gchar **var_units;

--- a/wscript
+++ b/wscript
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 # encoding: utf-8
 
-VERSION = '0.84.3'
+VERSION = '0.84.4'
 APPNAME = 'oregano'
 
 top = '.'


### PR DESCRIPTION
What's new:

- current will be plotted by setting the checkbox of "Simulation Settings"->"Transient"->"Analyze All Currents And Potentials (only ngspice)"
- no limitation of number of nodes to analyze any more (it was limited to max 9)
- elimination of some memory leaks
- function `void parse_transient_analysis (OreganoNgSpice *ngspice, gchar *tmp)` has no memory leaks (checked with help of `valgrind --tool=massif`)
- increased third number of oregano version from `0.84.3` to `0.84.4`, because it's only a small feature
- making code a bit prettier (deprecation, unused variables, ...)