### PR TITLE
ngspice not responding, output info in progress window, closes #185

### DIFF
--- a/src/engines/ngspice-analysis.c
+++ b/src/engines/ngspice-analysis.c
@@ -448,6 +448,7 @@ static ParseTransientAnalysisReturnResources parse_transient_analysis_resources 
 
 	g_mutex_lock(&progress_reader->progress_mutex);
 	progress_reader->progress = 0;
+	progress_reader->time = g_get_monotonic_time();
 	g_mutex_unlock(&progress_reader->progress_mutex);
 
 	gsize size;
@@ -500,6 +501,7 @@ static ParseTransientAnalysisReturnResources parse_transient_analysis_resources 
 					progress_reader->progress = (double)count_of_variables_already_finished / (double)no_of_variables +
 							(double)len_of_current_variables / (double)no_of_variables *
 							(double)get_current_index(ngspice_table) / (double)no_of_data_rows;
+					progress_reader->time = g_get_monotonic_time();
 					g_mutex_unlock(&progress_reader->progress_mutex);
 					// estimate progress end
 

--- a/src/engines/ngspice-analysis.h
+++ b/src/engines/ngspice-analysis.h
@@ -50,6 +50,8 @@
  */
 typedef struct {
 	gdouble progress;
+	// time (from g_get_monotonic_time) of the last writing access
+	gint64 time;
 	GMutex progress_mutex;
 } ProgressResources;
 

--- a/src/engines/ngspice.c
+++ b/src/engines/ngspice.c
@@ -374,6 +374,15 @@ static GList *ngspice_get_results (OreganoEngine *self)
 
 static gchar *ngspice_get_operation_ngspice (OreganoEngine *self)
 {
+	OreganoNgSpicePriv *priv = OREGANO_NGSPICE (self)->priv;
+
+	g_mutex_lock(&priv->progress_ngspice.progress_mutex);
+	gint64 old_time = priv->progress_ngspice.time;
+	g_mutex_unlock(&priv->progress_ngspice.progress_mutex);
+
+	gint64 new_time = g_get_monotonic_time();
+	if (new_time - old_time >= 1000000)
+		return g_strdup("ngspice not responding");
 	return g_strdup(_("ngspice solving"));
 }
 
@@ -409,8 +418,10 @@ static void ngspice_instance_init (GTypeInstance *instance, gpointer g_class)
 
 	self->priv = g_new0 (OreganoNgSpicePriv, 1);
 	self->priv->progress_ngspice.progress = 0.0;
+	self->priv->progress_ngspice.time = g_get_monotonic_time();
 	g_mutex_init(&self->priv->progress_ngspice.progress_mutex);
 	self->priv->progress_reader.progress = 0.0;
+	self->priv->progress_reader.time = g_get_monotonic_time();
 	g_mutex_init(&self->priv->progress_reader.progress_mutex);
 	self->priv->current.type = ANALYSIS_TYPE_NONE;
 	g_mutex_init(&self->priv->current.mutex);

--- a/src/simulation.c
+++ b/src/simulation.c
@@ -161,10 +161,9 @@ void simulation_show_progress_bar (GtkWidget *widget, SchematicView *sv)
 
 static int progress_bar_timeout_cb (Simulation *s)
 {
-	double p;
 	g_return_val_if_fail (s != NULL, FALSE);
 
-	p = 0;
+	double p = 0;
 	oregano_engine_get_progress_solver (s->engine, &p);
 
 	gtk_progress_bar_set_fraction (GTK_PROGRESS_BAR (s->progress_solver), p);


### PR DESCRIPTION
# ngspice not responding
## What's new

- If ngspice is not responding for more than 1s, the progress label of ngspice will change from `ngspice solving` to `ngspice not responding`. 1s is justified, because in normal operation mode ngspice outputs every 250ms a new "reference value" (progress information), so if 1s passed, ngspice missed 4 progress information outputs.
- The GUI will not hang up if ngspice hangs up, so the user can cancel the operation.