### PR TITLE
repair ngspice watcher test, closes #182

### DIFF
--- a/src/engines/ngspice-watcher.c
+++ b/src/engines/ngspice-watcher.c
@@ -521,7 +521,7 @@ void ngspice_watcher_build_and_launch(const NgspiceWatcherBuildAndLaunchResource
 		                              &e)) {
 
 		*aborted = TRUE;
-		log.log_append_error(log.log, _("Unable to execute NgSpice."));
+		log.log_append_error(log.log, _("Unable to execute NgSpice.\n"));
 		g_signal_emit_by_name (G_OBJECT (emit_instance), "aborted");
 		g_clear_error (&e);
 		g_printf("asdf2\n");

--- a/src/engines/ngspice-watcher.c
+++ b/src/engines/ngspice-watcher.c
@@ -510,6 +510,7 @@ void ngspice_watcher_build_and_launch(const NgspiceWatcherBuildAndLaunchResource
 
 	gint ngspice_stdout_fd;
 	gint ngspice_stderr_fd;
+	g_printf("asdf\n");
 	// Launch ngspice
 	if (!g_spawn_async_with_pipes (NULL, // Working directory
 		                              argv, NULL, G_SPAWN_DO_NOT_REAP_CHILD | G_SPAWN_SEARCH_PATH, NULL,
@@ -526,6 +527,7 @@ void ngspice_watcher_build_and_launch(const NgspiceWatcherBuildAndLaunchResource
 		return;
 
 	}
+	g_printf("jkloe\n");
 
 	// synchronizes stderr listener with is_ngspice_finished listener (needed for error handling)
 	IsNgspiceStderrDestroyed *is_ngspice_stderr_destroyed = g_new0(IsNgspiceStderrDestroyed, 1);

--- a/src/engines/ngspice-watcher.c
+++ b/src/engines/ngspice-watcher.c
@@ -510,7 +510,6 @@ void ngspice_watcher_build_and_launch(const NgspiceWatcherBuildAndLaunchResource
 
 	gint ngspice_stdout_fd;
 	gint ngspice_stderr_fd;
-	g_printf("asdf\n");
 	// Launch ngspice
 	if (!g_spawn_async_with_pipes (NULL, // Working directory
 		                              argv, NULL, G_SPAWN_DO_NOT_REAP_CHILD | G_SPAWN_SEARCH_PATH, NULL,
@@ -524,11 +523,9 @@ void ngspice_watcher_build_and_launch(const NgspiceWatcherBuildAndLaunchResource
 		log.log_append_error(log.log, _("Unable to execute NgSpice.\n"));
 		g_signal_emit_by_name (G_OBJECT (emit_instance), "aborted");
 		g_clear_error (&e);
-		g_printf("asdf2\n");
 		return;
 
 	}
-	g_printf("jkloe\n");
 
 	// synchronizes stderr listener with is_ngspice_finished listener (needed for error handling)
 	IsNgspiceStderrDestroyed *is_ngspice_stderr_destroyed = g_new0(IsNgspiceStderrDestroyed, 1);

--- a/src/engines/ngspice-watcher.c
+++ b/src/engines/ngspice-watcher.c
@@ -524,6 +524,7 @@ void ngspice_watcher_build_and_launch(const NgspiceWatcherBuildAndLaunchResource
 		log.log_append_error(log.log, _("Unable to execute NgSpice."));
 		g_signal_emit_by_name (G_OBJECT (emit_instance), "aborted");
 		g_clear_error (&e);
+		g_printf("asdf2\n");
 		return;
 
 	}

--- a/test/test_engine_ngspice.c
+++ b/test/test_engine_ngspice.c
@@ -128,10 +128,9 @@ static void test_engine_ngspice_basic() {
 	g_free(test_dir);
 
 	ngspice_watcher_build_and_launch(test_resources->resources);
-	g_assert_true(FALSE);
 	g_main_loop_run(test_resources->loop);
 //	print_log(test_resources->log_list);
-
+	g_assert_true(FALSE);
 	test_engine_ngspice_resources_finalize(test_resources);
 
 	gchar *actual_content;

--- a/test/test_engine_ngspice.c
+++ b/test/test_engine_ngspice.c
@@ -113,6 +113,8 @@ static gchar* test_engine_ngspice_get_test_dir_base() {
 }
 
 static void test_engine_ngspice_basic() {
+	g_printf("asdf\n");
+	g_assert_true(FALSE);
 
 	TestEngineNgspiceResources *test_resources = test_engine_ngspice_resources_new();
 

--- a/test/test_engine_ngspice.c
+++ b/test/test_engine_ngspice.c
@@ -114,6 +114,11 @@ static gchar* test_engine_ngspice_get_test_dir_base() {
 	g_free(cwd);
 	g_strfreev(splitted);
 	g_printf("test_dir = %s\n", test_dir);
+
+	GDir *gdir = g_dir_open(cwd, 0, NULL);
+	for (const gchar *dir_name = g_dir_read_name(gdir); dir_name != NULL; dir_name = g_dir_read_name(gdir))
+		g_printf("%s\n", dir_name);
+
 	g_assert_true(FALSE);
 
 	return test_dir;

--- a/test/test_engine_ngspice.c
+++ b/test/test_engine_ngspice.c
@@ -109,11 +109,12 @@ static gchar* test_engine_ngspice_get_test_dir_base() {
 	gchar **splitted = g_regex_split_simple("\\/build(?:.(?!\\/build))+$", cwd, 0, 0);
 	for (gchar **ptr = splitted; *ptr != NULL; ptr++)
 		g_printf("%s\n", *ptr);
-	g_assert_true(FALSE);
-	g_free(cwd);
 
-	gchar *test_dir = g_strdup_printf("%s/test", *splitted);
+	gchar *test_dir = g_strdup_printf("%s/test", cwd);
+	g_free(cwd);
 	g_strfreev(splitted);
+	g_printf("test_dir = %s\n", test_dir);
+	g_assert_true(FALSE);
 
 	return test_dir;
 }

--- a/test/test_engine_ngspice.c
+++ b/test/test_engine_ngspice.c
@@ -111,7 +111,6 @@ static gchar* test_engine_ngspice_get_test_dir_base() {
 		g_printf("%s\n", *ptr);
 
 	gchar *test_dir = g_strdup_printf("%s/test", cwd);
-	g_free(cwd);
 	g_strfreev(splitted);
 	g_printf("test_dir = %s\n", test_dir);
 
@@ -119,6 +118,7 @@ static gchar* test_engine_ngspice_get_test_dir_base() {
 	for (const gchar *dir_name = g_dir_read_name(gdir); dir_name != NULL; dir_name = g_dir_read_name(gdir))
 		g_printf("%s\n", dir_name);
 
+	g_free(cwd);
 	g_assert_true(FALSE);
 
 	return test_dir;

--- a/test/test_engine_ngspice.c
+++ b/test/test_engine_ngspice.c
@@ -111,7 +111,7 @@ static gchar* test_engine_ngspice_get_test_dir_base() {
 }
 
 static void test_engine_ngspice_basic() {
-asdf
+
 	TestEngineNgspiceResources *test_resources = test_engine_ngspice_resources_new();
 
 	gchar *test_dir = test_engine_ngspice_get_test_dir_base();
@@ -128,6 +128,7 @@ asdf
 	g_free(test_dir);
 
 	ngspice_watcher_build_and_launch(test_resources->resources);
+	g_assert_true(FALSE);
 	g_main_loop_run(test_resources->loop);
 //	print_log(test_resources->log_list);
 

--- a/test/test_engine_ngspice.c
+++ b/test/test_engine_ngspice.c
@@ -130,6 +130,7 @@ static void test_engine_ngspice_basic() {
 	test_resources->resources->ngspice_result_file = g_strdup_printf("%s/test-files/test_engine_ngspice_watcher/basic/result/actual.txt", test_dir);
 
 	gchar *actual_file = g_strdup_printf("%s/test-files/test_engine_ngspice_watcher/basic/result/actual.txt", test_dir);
+	g_remove(actual_file);
 	gchar *expected_file = g_strdup_printf("%s/test-files/test_engine_ngspice_watcher/basic/result/expected.txt", test_dir);
 
 	g_free(test_dir);

--- a/test/test_engine_ngspice.c
+++ b/test/test_engine_ngspice.c
@@ -104,10 +104,12 @@ static void test_engine_ngspice_resources_finalize(TestEngineNgspiceResources *t
 static gchar* test_engine_ngspice_get_test_dir_base() {
 	gchar *cwd = g_get_current_dir();
 
-	g_printf("%s\n", cwd);
-	g_assert_true(FALSE);
+	g_printf("cwd = %s\n", cwd);
 
 	gchar **splitted = g_regex_split_simple("\\/build(?:.(?!\\/build))+$", cwd, 0, 0);
+	for (gchar **ptr = splitted; *ptr != NULL; ptr++)
+		g_printf("%s\n", *ptr);
+	g_assert_true(FALSE);
 	g_free(cwd);
 
 	gchar *test_dir = g_strdup_printf("%s/test", *splitted);

--- a/test/test_engine_ngspice.c
+++ b/test/test_engine_ngspice.c
@@ -103,6 +103,10 @@ static void test_engine_ngspice_resources_finalize(TestEngineNgspiceResources *t
 
 static gchar* test_engine_ngspice_get_test_dir_base() {
 	gchar *cwd = g_get_current_dir();
+
+	g_printf("%s\n", cwd);
+	g_assert_true(FALSE);
+
 	gchar **splitted = g_regex_split_simple("\\/build(?:.(?!\\/build))+$", cwd, 0, 0);
 	g_free(cwd);
 
@@ -113,8 +117,6 @@ static gchar* test_engine_ngspice_get_test_dir_base() {
 }
 
 static void test_engine_ngspice_basic() {
-	g_printf("asdf\n");
-	g_assert_true(FALSE);
 
 	TestEngineNgspiceResources *test_resources = test_engine_ngspice_resources_new();
 

--- a/test/test_engine_ngspice.c
+++ b/test/test_engine_ngspice.c
@@ -137,7 +137,6 @@ static void test_engine_ngspice_basic() {
 	ngspice_watcher_build_and_launch(test_resources->resources);
 	g_main_loop_run(test_resources->loop);
 //	print_log(test_resources->log_list);
-	g_assert_true(FALSE);
 	test_engine_ngspice_resources_finalize(test_resources);
 
 	gchar *actual_content;

--- a/test/test_engine_ngspice.c
+++ b/test/test_engine_ngspice.c
@@ -136,6 +136,7 @@ static void test_engine_ngspice_basic() {
 	g_free(test_dir);
 
 	ngspice_watcher_build_and_launch(test_resources->resources);
+	print_log(test_resources->log_list);
 	g_main_loop_run(test_resources->loop);
 //	print_log(test_resources->log_list);
 	test_engine_ngspice_resources_finalize(test_resources);

--- a/test/test_engine_ngspice.c
+++ b/test/test_engine_ngspice.c
@@ -111,7 +111,7 @@ static gchar* test_engine_ngspice_get_test_dir_base() {
 }
 
 static void test_engine_ngspice_basic() {
-
+asdf
 	TestEngineNgspiceResources *test_resources = test_engine_ngspice_resources_new();
 
 	gchar *test_dir = test_engine_ngspice_get_test_dir_base();

--- a/test/test_engine_ngspice.c
+++ b/test/test_engine_ngspice.c
@@ -176,7 +176,6 @@ static void test_engine_ngspice_error_no_such_file_or_directory() {
 
 	g_assert_nonnull(test_resources->log_list);
 	g_assert_true(g_str_has_suffix(test_resources->log_list->data, " No such file or directory\n"));
-	print_log(test_resources->log_list);
 
 	test_engine_ngspice_resources_finalize(test_resources);
 }

--- a/test/test_engine_ngspice.c
+++ b/test/test_engine_ngspice.c
@@ -33,6 +33,11 @@ static void test_engine_ngspice_aborted(gpointer emit_instance, GMainLoop *loop)
 	g_main_loop_quit(loop);
 }
 
+static gboolean test_engine_ngspice_timeout(GMainLoop *loop) {
+	g_main_loop_quit(loop);
+	return FALSE;
+}
+
 static void print_log(const GList *list) {
 	for (const GList *walker = list; walker; walker = walker->next)
 		g_printf("%s", (char *)walker->data);
@@ -44,6 +49,7 @@ typedef struct {
 	GMainLoop *loop;
 	gulong handler_id_done;
 	gulong handler_id_aborted;
+	guint handler_id_timeout;
 	GList *log_list;
 	SimSettings *sim_settings;
 } TestEngineNgspiceResources;
@@ -60,6 +66,7 @@ static TestEngineNgspiceResources *test_engine_ngspice_resources_new() {
 	GMainLoop *loop = test_resources->loop;
 	test_resources->handler_id_done = g_signal_connect(G_OBJECT(ngspice), "done", G_CALLBACK(test_engine_ngspice_done), loop);
 	test_resources->handler_id_aborted = g_signal_connect(G_OBJECT(ngspice), "aborted", G_CALLBACK(test_engine_ngspice_aborted), loop);
+	test_resources->handler_id_timeout = g_timeout_add(10000, (GSourceFunc)test_engine_ngspice_timeout, loop);
 
 	resources->aborted = &ngspice->priv->aborted;
 	resources->analysis = &ngspice->priv->analysis;

--- a/test/test_engine_ngspice.c
+++ b/test/test_engine_ngspice.c
@@ -104,22 +104,8 @@ static void test_engine_ngspice_resources_finalize(TestEngineNgspiceResources *t
 static gchar* test_engine_ngspice_get_test_dir_base() {
 	gchar *cwd = g_get_current_dir();
 
-	g_printf("cwd = %s\n", cwd);
-
-	gchar **splitted = g_regex_split_simple("\\/build(?:.(?!\\/build))+$", cwd, 0, 0);
-	for (gchar **ptr = splitted; *ptr != NULL; ptr++)
-		g_printf("%s\n", *ptr);
-
 	gchar *test_dir = g_strdup_printf("%s/test", cwd);
-	g_strfreev(splitted);
-	g_printf("test_dir = %s\n", test_dir);
-
-	GDir *gdir = g_dir_open(cwd, 0, NULL);
-	for (const gchar *dir_name = g_dir_read_name(gdir); dir_name != NULL; dir_name = g_dir_read_name(gdir))
-		g_printf("%s\n", dir_name);
-
 	g_free(cwd);
-	g_assert_true(FALSE);
 
 	return test_dir;
 }

--- a/test/test_engine_ngspice.c
+++ b/test/test_engine_ngspice.c
@@ -137,8 +137,8 @@ static void test_engine_ngspice_basic() {
 
 	ngspice_watcher_build_and_launch(test_resources->resources);
 	print_log(test_resources->log_list);
+	g_assert_null(test_resources->log_list);
 	g_main_loop_run(test_resources->loop);
-//	print_log(test_resources->log_list);
 	test_engine_ngspice_resources_finalize(test_resources);
 
 	gchar *actual_content;


### PR DESCRIPTION
# ngspice watcher test
## Analysis
As you can see, ngspice is missing on the test system.

## Fixing

- Install ngspice on test system.
- Implement an ngspice interface and emulate ngspice through that interface in the test system.