### PR TITLE
Dynamically determine the size of the schematic / sheet

### DIFF
--- a/src/engines/ngspice-analysis.c
+++ b/src/engines/ngspice-analysis.c
@@ -873,7 +873,7 @@ static ThreadPipe *parse_noise_analysis (NgspiceAnalysisResources *resources)
 	tm->title = g_strdup ("Integrated Noise (V<sup>2</sup> or A<sup>2</sup>)");
 	tm->msg = g_strdup_printf ("Input: %f\nOutput: %f\n", inoise, onoise);
 
-	g_idle_add_full (G_PRIORITY_DEFAULT_IDLE, (GSourceFunc) oregano_schedule_warning_with_title, tm, NULL);
+	oregano_warning_with_title (tm->title, tm->msg);
 
 	*analysis = g_list_append (*analysis, sdata);
 	(*num_analysis)++;
@@ -1014,7 +1014,7 @@ void ngspice_analysis (NgspiceAnalysisResources *resources)
 		NG_DEBUG ("%d buf = %s", i, *buf);
 
 		if (!get_analysis_type(*buf, &analysis_type) && !noise_enabled && i == 0) {
-			g_idle_add_full (G_PRIORITY_DEFAULT_IDLE, (GSourceFunc) oregano_schedule_warning, "No analysis found", NULL);
+			oregano_warning ("No analysis found");
 			break;
 		}
 
@@ -1042,7 +1042,7 @@ void ngspice_analysis (NgspiceAnalysisResources *resources)
 			ac_enabled = FALSE;
 			break;
 		default:
-			g_idle_add_full (G_PRIORITY_DEFAULT_IDLE, (GSourceFunc) oregano_schedule_warning, "Unexpected analysis found", NULL);
+			oregano_warning ("Unexpected analysis found");
 			unexpected_analysis_found = TRUE;
 			break;
 		}

--- a/src/engines/ngspice-analysis.c
+++ b/src/engines/ngspice-analysis.c
@@ -847,22 +847,33 @@ static gdouble parse_noise_total(gchar *line) {
 static ThreadPipe *parse_noise_analysis (NgspiceAnalysisResources *resources)
 {
 	ThreadPipe *pipe = resources->pipe;
+	gboolean input;
+	guint i;
         gchar **buf = &resources->buf;
+	gchar **splitted;
+	const SimSettings* const sim_settings = resources->sim_settings;
 	GList **analysis = resources->analysis;
         gsize size;
-	gdouble inoise, onoise;
+	gdouble inoise, onoise, prev_seq, seq, frequency, inoise_psd, onoise_psd;
+	gdouble val[3];
 	guint *num_analysis = resources->num_analysis;
 	OreganoTitleMsg *tm;
-
         static SimulationData *sdata;
         static Analysis *data;
+	FILE *fp;
+	char fbuffer[BSIZE_SP];
 
         NG_DEBUG ("Noise: result str\n>>>\n%s\n<<<", *buf);
 
         data = g_new0 (Analysis, 1);
         sdata = SIM_DATA (data);
-        sdata->type = ANALYSIS_TYPE_NOISE;
+        sdata->type = ANALYSIS_TYPE_INTEGRATED_NOISE;
         sdata->functions = NULL;
+
+	ANALYSIS (sdata)->noise.sim_length = 1.;
+	ANALYSIS (sdata)->noise.sim_length = (double) sim_settings_get_noise_npoints (sim_settings);
+	ANALYSIS (sdata)->noise.start = sim_settings_get_noise_start (sim_settings);
+	ANALYSIS (sdata)->noise.stop = sim_settings_get_noise_stop (sim_settings);
 
 	// Parse integrated noise (V^2 or A^2)
 	inoise = parse_noise_total(*buf);
@@ -877,6 +888,95 @@ static ThreadPipe *parse_noise_analysis (NgspiceAnalysisResources *resources)
 
 	*analysis = g_list_append (*analysis, sdata);
 	(*num_analysis)++;
+
+	if ((fp = fopen (NOISE_ANALYSIS_FILENAME, "r")) == NULL) {
+		printf ("Cannot open noise analysis output file %s: noise spectrum will not be available !\n", NOISE_ANALYSIS_FILENAME);
+		return pipe;
+	}
+
+	// Prepare to read the noise power spectral density
+	sdata->var_names = (char **)g_new0 (gpointer, 3);
+	sdata->var_units = (char **)g_new0 (gpointer, 3);
+	sdata->var_names[0] = g_strdup ("Frequency");
+	sdata->var_units[0] = g_strdup (_ ("frequency"));
+	sdata->var_names[1] = g_strdup ("Input Noise PSD");
+	sdata->var_units[1] = g_strdup (_ ("psd"));
+	sdata->var_names[2] = g_strdup ("Output Noise PSD");
+	sdata->var_units[2] = g_strdup (_ ("psd"));
+
+        sdata->n_variables = 3;
+        sdata->got_points = 0;
+        sdata->got_var = 0;
+        sdata->data = (GArray **)g_new0 (gpointer, 3);
+
+        for (i = 0; i < 3; i++)
+                sdata->data[i] = g_array_new (TRUE, TRUE, sizeof(double));
+
+        sdata->min_data = g_new (double, 3);
+        sdata->max_data = g_new (double, 3);
+
+        for (i = 0; i < 3; i++) {
+                sdata->min_data[i] = G_MAXDOUBLE;
+                sdata->max_data[i] = -G_MAXDOUBLE;
+        }
+
+	// Read the noise power spectral density
+	while (!g_str_has_prefix (fbuffer, "Values:")) {
+		if (fgets(fbuffer, BSIZE_SP, fp) == NULL)
+			break;
+	}
+
+	seq = -1;
+	input = FALSE;
+	while (fgets(fbuffer, BSIZE_SP, fp)) {
+		frequency = 0.;
+		inoise_psd = 0.;
+		onoise_psd = 0.;
+		splitted = g_regex_split_simple("[\t]*([0-9]*)[\t]*([\\+\\-]{0,1}[0-9]\\.[0-9]*[Ee][\\+\\-][0-9]*)\n",
+							&fbuffer, 0, 0);
+		if (splitted[1]) {
+			if (*splitted[1]) {
+				prev_seq = seq;
+				seq = g_ascii_strtod(splitted[1], NULL);
+				// simple sequence sanity check
+				if (seq == prev_seq + 1)
+					sdata->got_points++;
+				if (splitted[2]) {
+					frequency = g_ascii_strtod(splitted[2], NULL);
+					val[0] = frequency;
+				}
+			} else {
+				if (splitted[2]) {
+					if (input) {
+						inoise_psd = g_ascii_strtod(splitted[2], NULL);
+						val[1] = inoise_psd;
+					} else {
+						onoise_psd = g_ascii_strtod(splitted[2], NULL);
+						val[2] = onoise_psd;
+						for (i = 0; i < 3; i++) {
+							sdata->data[i] = g_array_append_val (sdata->data[i], val[i]);
+							if (val[i] < sdata->min_data[i])
+								sdata->min_data[i] = val[i];
+							if (val[i] > sdata->max_data[i])
+								sdata->max_data[i] = val[i];
+						}
+					}
+				}
+			}
+		}
+
+		g_strfreev(splitted);
+		input = !input;
+	}
+
+	sdata->got_var = 3;
+	if (sdata->got_points)
+		sdata->type = ANALYSIS_TYPE_NOISE;
+
+	if (fp) {
+		fclose (fp);
+		unlink (NOISE_ANALYSIS_FILENAME);
+	}
 
 	return pipe;
 }

--- a/src/engines/ngspice-analysis.c
+++ b/src/engines/ngspice-analysis.c
@@ -926,9 +926,6 @@ static ThreadPipe *parse_noise_analysis (NgspiceAnalysisResources *resources)
 			return pipe;
 	}
 
-	sdata->type = ANALYSIS_TYPE_NOISE;
-	sdata->got_var = 3;
-
 	seq = -1;
 	input = FALSE;
 	while (fgets(fbuffer, BSIZE_SP, fp)) {

--- a/src/engines/ngspice-analysis.h
+++ b/src/engines/ngspice-analysis.h
@@ -4,12 +4,14 @@
  * Authors:
  *  Ricardo Markiewicz <rmarkie@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
+ *  Guido Trentalancia <guido@trentalancia.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
  * Copyright (C) 1999-2001  Richard Hult
  * Copyright (C) 2003,2006  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
+ * Copyright (C) 2017       Guido Trentalancia
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -42,6 +44,12 @@
 #include "dialogs.h"
 #include "engine-internal.h"
 #include "ngspice.h"
+
+/*
+ * The file buffer size (recommended value
+ * is 512 bytes).
+ */
+#define BSIZE_SP	512
 
 /**
  * Progress is a shared variable between GUI thread

--- a/src/engines/ngspice.c
+++ b/src/engines/ngspice.c
@@ -292,12 +292,14 @@ static GString *ngspice_generate_netlist_buffer (OreganoEngine *engine, GError *
 		                        sim_settings_get_noise_npoints (output.settings),
 		                        sim_settings_get_noise_start (output.settings),
 		                        sim_settings_get_noise_stop (output.settings));
-	                g_string_append_printf (buffer, "\n.control\n");
-			g_string_append_printf (buffer, "  listing e\n");
-			g_string_append_printf (buffer, "  run\n");
-			g_string_append_printf (buffer, "  print v(inoise_total) v(onoise_total)\n");
-			g_string_append_printf (buffer, "  quit\n");
-			g_string_append_printf (buffer, ".endc\n");
+	                g_string_append (buffer, "\n.control\n");
+			g_string_append (buffer, "  listing e\n");
+			g_string_append (buffer, "  run\n");
+			g_string_append (buffer, "  set filetype=ascii\n");
+			g_string_append (buffer, "  print v(inoise_total) v(onoise_total)\n");
+			g_string_append_printf (buffer, "  write oregano-noise.txt noise1.all\n", NOISE_ANALYSIS_FILENAME);
+			g_string_append (buffer, "  quit\n");
+			g_string_append (buffer, ".endc\n");
 		}
 	}
 

--- a/src/engines/ngspice.h
+++ b/src/engines/ngspice.h
@@ -4,12 +4,14 @@
  * Authors:
  *  Ricardo Markiewicz <rmarkie@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
+ *  Guido Trentalancia <guido@trentalancia.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
  * Copyright (C) 1999-2001  Richard Hult
  * Copyright (C) 2003,2006  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
+ * Copyright (C) 2017       Guido Trentalancia
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -29,6 +31,12 @@
 
 #ifndef __NGSPICE_H
 #define __NGSPICE_H
+
+/*
+ * The filename used for the temporary noise
+ * analysis file.
+ */
+#define	NOISE_ANALYSIS_FILENAME	"oregano-noise.txt"
 
 #include <gtk/gtk.h>
 

--- a/src/load-schematic.c
+++ b/src/load-schematic.c
@@ -44,6 +44,7 @@
 #include "load-schematic.h"
 #include "coords.h"
 #include "part-label.h"
+#include "schematic.h"
 #include "sim-settings.h"
 #include "textbox.h"
 #include "errors.h"
@@ -763,6 +764,7 @@ static void start_element (ParseState *state, const xmlChar *name, const xmlChar
 static void end_element (ParseState *state, const xmlChar *name)
 {
 	GList *libs;
+	Schematic *schematic = state->schematic;
 
 	switch (state->state) {
 	case PARSE_UNKNOWN:
@@ -988,6 +990,16 @@ static void end_element (ParseState *state, const xmlChar *name)
 		break;
 	case PARSE_PART_POSITION:
 		sscanf (state->content->str, "(%lf %lf)", &state->pos.x, &state->pos.y);
+		// Try to fix invalid positions
+		if (state->pos.x < 0)
+			state->pos.x = -state->pos.x;
+		if (state->pos.y < 0)
+			state->pos.y = -state->pos.y;
+		// Determine the maximum parts' coordinates to be used during sheet creation
+		if (state->pos.x > schematic_get_width(schematic))
+			schematic_set_width(schematic, (guint) state->pos.x);
+		if (state->pos.y > schematic_get_height(schematic))
+			schematic_set_height(schematic, (guint) state->pos.y);
 		state->state = PARSE_PART;
 		break;
 	case PARSE_PART_ROTATION:

--- a/src/model/item-data.c
+++ b/src/model/item-data.c
@@ -260,42 +260,6 @@ void item_data_move (ItemData *item_data, const Coords *delta)
 	cairo_matrix_translate (&(priv->translate), delta->x, delta->y);
 }
 
-/**
- * \brief snaps to the grid, updates the model if snapping was necessary
- *
- * \attention this will cause a loop cycle of "changed" signals
- *            until no more snapping is necessary
- *
- * @param item_data
- * @param grid
- */
-void item_data_snap (ItemData *item_data, Grid *grid)
-{
-	gboolean handler_connected;
-
-	g_return_if_fail (item_data);
-	g_return_if_fail (IS_ITEM_DATA (item_data));
-	g_return_if_fail (grid);
-	g_return_if_fail (IS_GRID (grid));
-
-	if (snap_to_grid (grid, &(item_data->priv->translate.x0), &(item_data->priv->translate.y0))) {
-
-#if 1 // TODO FIXME XXX rename this to "snapped" instead of moved
-		handler_connected =
-		    g_signal_handler_is_connected (G_OBJECT (item_data), item_data->moved_handler_id);
-		if (handler_connected) {
-			g_signal_emit_by_name (G_OBJECT (item_data),
-			                       "moved"); // FIXME replace this by a "snapped" signal
-		}
-#endif
-		handler_connected =
-		    g_signal_handler_is_connected (G_OBJECT (item_data), item_data->changed_handler_id);
-		if (handler_connected) {
-			g_signal_emit_by_name (G_OBJECT (item_data), "changed");
-		}
-	}
-}
-
 // NodeStore *
 gpointer item_data_get_store (ItemData *item_data)
 {

--- a/src/model/item-data.h
+++ b/src/model/item-data.h
@@ -138,9 +138,6 @@ void item_data_flip (ItemData *data, IDFlip direction, Coords *center);
 //  Store is a class that hold all items in a schematic
 gpointer item_data_get_store (ItemData *item_data);
 
-// Snap to the grid
-void item_data_snap (ItemData *item_data, Grid *grid);
-
 //  Unregister item in its Store
 void item_data_unregister (ItemData *data);
 

--- a/src/model/part.c
+++ b/src/model/part.c
@@ -695,7 +695,6 @@ static void part_flip (ItemData *data, IDFlip direction, Coords *center)
 		priv->pins[i].offset.x = x;
 		priv->pins[i].offset.y = y;
 	}
-	item_data_snap (data);
 
 	// tell the view
 	handler_connected = g_signal_handler_is_connected (G_OBJECT (part),

--- a/src/model/schematic.c
+++ b/src/model/schematic.c
@@ -8,6 +8,7 @@
  *  Andres de Barbara <adebarbara@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
  *  Bernhard Schuster <bernhard@ahoi.io>
+ *  Guido Trentalancia <guido@trentalancia.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
@@ -15,6 +16,7 @@
  * Copyright (C) 2003,2006  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
  * Copyright (C) 2013       Bernhard Schuster
+ * Copyright (C) 2017       Guido Trentalancia
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -80,6 +82,9 @@ struct _SchematicPriv
 	NodeStore *store;
 	GHashTable *symbols;
 	GHashTable *refdes_values;
+
+	guint width;
+	guint height;
 
 	double zoom;
 
@@ -216,6 +221,8 @@ static void schematic_init (Schematic *schematic)
 	priv->symbols = g_hash_table_new (g_str_hash, g_str_equal);
 	priv->refdes_values = g_hash_table_new (g_str_hash, g_str_equal);
 	priv->store = node_store_new ();
+	priv->width = 0;
+	priv->height = 0;
 	priv->dirty = FALSE;
 	priv->logstore = log_new ();
 	priv->log = gtk_text_buffer_new (NULL); // LEGACY
@@ -414,6 +421,38 @@ void schematic_set_netlist_filename (Schematic *schematic, char *filename)
 		g_free (schematic->priv->netlist_filename);
 
 	schematic->priv->netlist_filename = g_strdup (filename);
+}
+
+guint schematic_get_width (const Schematic *schematic)
+{
+	g_return_val_if_fail (schematic != NULL, 0.);
+	g_return_val_if_fail (IS_SCHEMATIC (schematic), 0.);
+
+	return schematic->priv->width;
+}
+
+void schematic_set_width (Schematic *schematic, const guint width)
+{
+	g_return_if_fail (schematic != NULL);
+	g_return_if_fail (IS_SCHEMATIC (schematic));
+
+	schematic->priv->width = width;
+}
+
+guint schematic_get_height (const Schematic *schematic)
+{
+	g_return_val_if_fail (schematic != NULL, 0.);
+	g_return_val_if_fail (IS_SCHEMATIC (schematic), 0.);
+
+	return schematic->priv->height;
+}
+
+void schematic_set_height (Schematic *schematic, const guint height)
+{
+	g_return_if_fail (schematic != NULL);
+	g_return_if_fail (IS_SCHEMATIC (schematic));
+
+	schematic->priv->height = height;
 }
 
 double schematic_get_zoom (Schematic *schematic)

--- a/src/model/schematic.h
+++ b/src/model/schematic.h
@@ -7,12 +7,14 @@
  *  Ricardo Markiewicz <rmarkie@fi.uba.ar>
  *  Andres de Barbara <adebarbara@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
+ *  Guido Trentalancia <guido@trentalancia.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
  * Copyright (C) 1999-2001  Richard Hult
  * Copyright (C) 2003,2004  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
+ * Copyright (C) 2017       Guido Trentalancia
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -103,7 +105,11 @@ void schematic_set_filename (Schematic *schematic, const gchar *filename);
 char *schematic_get_netlist_filename (Schematic *schematic);
 void schematic_set_netlist_filename (Schematic *schematic, char *filename);
 int schematic_count (void);
+guint schematic_get_width (const Schematic *schematic);
+guint schematic_get_height (const Schematic *schematic);
 double schematic_get_zoom (Schematic *schematic);
+void schematic_set_width (Schematic *schematic, const guint width);
+void schematic_set_height (Schematic *schematic, const guint height);
 void schematic_set_zoom (Schematic *schematic, double zoom);
 void schematic_add_item (Schematic *sm, ItemData *data);
 void schematic_parts_foreach (Schematic *schematic, ForeachItemDataFunc func, gpointer user_data);

--- a/src/model/wire.c
+++ b/src/model/wire.c
@@ -384,7 +384,6 @@ static void wire_rotate (ItemData *data, int angle, Coords *center_pos)
 		coords_add (&delta, &diff);
 	}
 	item_data_move (ITEM_DATA (wire), &delta);
-	//	item_data_snap (ITEM_DATA (wire), NULL); //FIXME XXX
 
 	// Let the views (canvas items) know about the rotation.
 	g_signal_emit_by_name (G_OBJECT (wire), "rotated", angle); // legacy

--- a/src/oregano-utils.c
+++ b/src/oregano-utils.c
@@ -7,12 +7,14 @@
  *  Ricardo Markiewicz <rmarkie@fi.uba.ar>
  *  Andres de Barbara <adebarbara@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
+ *  Guido Trentalancia <guido@trentalancia.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
  * Copyright (C) 1999-2001  Richard Hult
  * Copyright (C) 2003,2006  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
+ * Copyright (C) 2017       Guido Trentalancia
  *
  *
  * This program is free software; you can redistribute it and/or
@@ -34,51 +36,70 @@
 #include <string.h>
 #include <gtk/gtk.h>
 
+#include "debug.h"
 #include "oregano-utils.h"
 
-gdouble oregano_strtod (const gchar *str, const gchar unit)
+gdouble oregano_strtod (const gchar *str, const gchar *unit)
 {
+	gboolean unit_does_not_match = FALSE;
 	gdouble ret;
-	gchar *endptr, *c;
+	gchar *endptr, *c, **splitted;
+	size_t unit_length = 0;
+
+	if (unit)
+		unit_length = strlen (unit);
 
 	if (!str)
 		return 0.0;
 
 	ret = g_ascii_strtod (str, &endptr);
+
 	for (c = endptr; *c; c++) {
 		switch (*c) {
 		case 'T':
 			ret *= 1e12;
-			return ret;
+			break;
 		case 'G':
 			ret *= 1e9;
-			return ret;
+			break;
 		case 'M':
 			ret *= 1e6;
-			return ret;
+			break;
 		case 'k':
 			ret *= 1e3;
-			return ret;
+			break;
 		case 'm':
 			ret *= 1e-3;
-			return ret;
+			break;
 		case 'u':
 			ret *= 1e-6;
-			return ret;
+			break;
 		case 'n':
 			ret *= 1e-9;
-			return ret;
+			break;
 		case 'p':
 			ret *= 1e-12;
-			return ret;
+			break;
 		case 'f':
 			ret *= 1e-15;
-			return ret;
+			break;
 		default:
-			if (*c == unit)
-				return ret;
+			if (c)
+				splitted = g_strsplit (c, " ", 2);
+			if (splitted[1]) {
+				if (!g_ascii_strncasecmp (splitted[1], unit, unit_length)) {
+					return ret;
+				} else {
+					unit_does_not_match = TRUE;
+					break;
+				}
+			}
 			break;
 		}
 	}
+
+	if (unit_does_not_match)
+		g_printf ("Unexpected unit of measurement\n");	
+
 	return ret;
 }

--- a/src/oregano-utils.h
+++ b/src/oregano-utils.h
@@ -35,7 +35,7 @@
 #ifndef __OREGANO_UTILS_H
 #define __OREGANO_UTILS_H
 
-gdouble oregano_strtod (const gchar *str, const gchar unit);
+gdouble oregano_strtod (const gchar *str, const gchar *unit);
 
 #define DEGSANITY(x)                                                                               \
 	do {                                                                                           \

--- a/src/plot.c
+++ b/src/plot.c
@@ -8,6 +8,7 @@
  *  Andres de Barbara <adebarbara@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
  *  Bernhard Schuster <bernhard@ahoi.io>
+ *  Guido Trentalancia <guido@trentalancia.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
@@ -15,6 +16,7 @@
  * Copyright (C) 2003,2006  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
  * Copyright (C) 2013       Bernhard Schuster
+ * Copyright (C) 2017       Guido Trentalancia
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -128,6 +130,8 @@ static gchar *get_variable_units (gchar *str)
 		tmp = g_strdup ("Hz");
 	} else if (!strcmp (str, _ ("current"))) {
 		tmp = g_strdup ("A");
+	} else if (!strcmp (str, _ ("psd"))) {
+		tmp = g_strdup ("V^2 / Hz");
 	} else {
 		tmp = g_strdup ("##");
 	}
@@ -484,7 +488,7 @@ int plot_show (OreganoEngine *engine)
 	for (; analysis; analysis = analysis->next) {
 		sdat = SIM_DATA (analysis->data);
 		str = oregano_engine_get_analysis_name (sdat);
-		if (sdat->type != ANALYSIS_TYPE_OP_POINT && sdat->type != ANALYSIS_TYPE_NOISE)
+		if (sdat->type != ANALYSIS_TYPE_OP_POINT && sdat->type != ANALYSIS_TYPE_INTEGRATED_NOISE)
 			abort = FALSE;
 	}
 
@@ -510,7 +514,7 @@ int plot_show (OreganoEngine *engine)
 	for (; analysis_backup; analysis_backup = analysis_backup->next) {
 		sdat = SIM_DATA (analysis_backup->data);
 		str = oregano_engine_get_analysis_name (sdat);
-		if (sdat->type == ANALYSIS_TYPE_OP_POINT || sdat->type == ANALYSIS_TYPE_NOISE) {
+		if (sdat->type == ANALYSIS_TYPE_OP_POINT || sdat->type == ANALYSIS_TYPE_INTEGRATED_NOISE) {
 			continue;
 		}
 

--- a/src/schematic-view-menu.h
+++ b/src/schematic-view-menu.h
@@ -7,12 +7,14 @@
  *  Ricardo Markiewicz <rmarkie@fi.uba.ar>
  *  Andres de Barbara <adebarbara@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
+ *  Guido Trentalancia <guido@trentalancia.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
  * Copyright (C) 1999-2001  Richard Hult
  * Copyright (C) 2003,2006  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
+ * Copyright (C) 2017       Guido Trentalancia
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -35,6 +37,8 @@
 
 #include "sim-settings-gui.h"
 
+// TODO: Create only two entries instead of four for stretching the schematic horizontally
+//       or vertically (needs proper icons not provided by Gtk).
 static GtkActionEntry entries[] = {
     // Name, ICON, Text, CTRL, DESC, CALLBACK
     {"MenuFile", NULL, N_ ("_File")},
@@ -100,6 +104,14 @@ static GtkActionEntry entries[] = {
     {"ZoomIn", GTK_STOCK_ZOOM_IN, N_ ("Zoom _In"), NULL, N_ ("Zoom in"), G_CALLBACK (zoom_in_cmd)},
     {"ZoomOut", GTK_STOCK_ZOOM_OUT, N_ ("Zoom _Out"), NULL, N_ ("Zoom out"),
      G_CALLBACK (zoom_out_cmd)},
+    {"StretchLeft", GTK_STOCK_GO_BACK, N_ ("Stretch to the left"), NULL, N_ ("Stretch to the left"),
+     G_CALLBACK (stretch_horizontal_cmd)},
+    {"StretchRight", GTK_STOCK_GO_FORWARD, N_ ("Stretch to the right"), NULL, N_ ("Stretch to the right"),
+     G_CALLBACK (stretch_horizontal_cmd)},
+    {"StretchTop", GTK_STOCK_GO_UP, N_ ("Stretch the top"), NULL, N_ ("Stretch the top"),
+     G_CALLBACK (stretch_vertical_cmd)},
+    {"StretchBottom", GTK_STOCK_GO_DOWN, N_ ("Stretch the bottom"), NULL, N_ ("Stretch the bottom"),
+     G_CALLBACK (stretch_vertical_cmd)},
 };
 
 static GtkToggleActionEntry toggle_entries[] = {
@@ -210,6 +222,11 @@ static const char *ui_description = "<ui>"
                                     "    <toolitem action='ZoomIn'/>"
                                     "    <toolitem action='ZoomOut'/>"
                                     "    <separator/>"
+                                    "    <toolitem action='StretchLeft'/>"
+                                    "    <toolitem action='StretchRight'/>"
+                                    "    <toolitem action='StretchTop'/>"
+                                    "    <toolitem action='StretchBottom'/>"
+				    "    <separator/>"
                                     "    <toolitem action='Grid'/>"
                                     "    <toolitem action='Parts'/>"
                                     "    <toolitem action='LogView'/>"

--- a/src/schematic-view.c
+++ b/src/schematic-view.c
@@ -899,7 +899,7 @@ static void zoom_in_cmd (GtkWidget *widget, SchematicView *sv)
 	g_return_if_fail (sv != NULL);
 	g_return_if_fail (IS_SCHEMATIC_VIEW (sv));
 
-	sheet_change_zoom (sv->priv->sheet, 1.1);
+	sheet_zoom_step (sv->priv->sheet, 1.1);
 	zoom_check (sv);
 }
 
@@ -908,7 +908,7 @@ static void zoom_out_cmd (GtkWidget *widget, SchematicView *sv)
 	g_return_if_fail (sv != NULL);
 	g_return_if_fail (IS_SCHEMATIC_VIEW (sv));
 
-	sheet_change_zoom (sv->priv->sheet, 0.9);
+	sheet_zoom_step (sv->priv->sheet, 0.9);
 	zoom_check (sv);
 }
 

--- a/src/schematic-view.c
+++ b/src/schematic-view.c
@@ -943,6 +943,7 @@ static void stretch_horizontal_cmd (GtkWidget *widget, SchematicView *sv)
 	guint width;
 
 	g_return_if_fail (sv != NULL);
+	g_return_if_fail (IS_SCHEMATIC_VIEW (sv));
 
 	sm = sv->priv->schematic;
 
@@ -952,10 +953,11 @@ static void stretch_horizontal_cmd (GtkWidget *widget, SchematicView *sv)
 	width = schematic_get_width (sm);
 	schematic_set_width (sm, width * (1.0 + SCHEMATIC_STRETCH_FACTOR));
 
-	sheet_replace (sv);
-	schematic_view_reload (sv, sm);
+	if (sheet_replace (sv)) {
+		schematic_view_reload (sv, sm);
 
-	gtk_widget_show_all (schematic_view_get_toplevel (sv));
+		gtk_widget_show_all (schematic_view_get_toplevel (sv));
+	}
 }
 
 /*
@@ -967,6 +969,7 @@ static void stretch_vertical_cmd (GtkWidget *widget, SchematicView *sv)
 	guint height;
 
 	g_return_if_fail (sv != NULL);
+	g_return_if_fail (IS_SCHEMATIC_VIEW (sv));
 
 	sm = sv->priv->schematic;
 
@@ -976,10 +979,11 @@ static void stretch_vertical_cmd (GtkWidget *widget, SchematicView *sv)
 	height = schematic_get_height (sm);
 	schematic_set_height (sm, height * (1.0 + SCHEMATIC_STRETCH_FACTOR));
 
-	sheet_replace (sv);
-	schematic_view_reload (sv, sm);
+	if (sheet_replace (sv)) {
+		schematic_view_reload (sv, sm);
 
-	gtk_widget_show_all (schematic_view_get_toplevel (sv));
+		gtk_widget_show_all (schematic_view_get_toplevel (sv));
+	}
 }
 
 static void simulate_cmd (GtkWidget *widget, SchematicView *sv)
@@ -1753,7 +1757,7 @@ SchematicView *schematic_view_get_schematicview_from_sheet (Sheet *sheet)
 	g_return_val_if_fail (IS_SHEET (sheet), NULL);
 
 	GList *iter, *copy;
-	SchematicView *sv;
+	SchematicView *sv = NULL;
 
 	copy = g_list_copy (schematic_view_list); // really needed? probably not
 

--- a/src/schematic-view.c
+++ b/src/schematic-view.c
@@ -8,6 +8,7 @@
  *  Andres de Barbara <adebarbara@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
  *  Bernhard Schuster <bernhard@ahoi.io>
+ *  Guido Trentalancia <guido@trentalancia.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
@@ -15,6 +16,7 @@
  * Copyright (C) 2003,2006  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
  * Copyright (C) 2013-2014  Bernhard Schuster
+ * Copyright (C) 2017       Guido Trentalancia
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -41,6 +43,7 @@
 #include <sys/time.h>
 #include <cairo/cairo-features.h>
 
+#include "schematic.h"
 #include "schematic-view.h"
 #include "part-browser.h"
 #include "stock.h"
@@ -130,6 +133,8 @@ static void schematic_view_class_init (SchematicViewClass *klass);
 static void schematic_view_dispose (GObject *object);
 static void schematic_view_finalize (GObject *object);
 static void schematic_view_load (SchematicView *sv, Schematic *sm);
+static void schematic_view_do_load (SchematicView *sv, Schematic *sm, const gboolean reload);
+static void schematic_view_reload (SchematicView *sv, Schematic *sm);
 
 // Signal callbacks.
 static void title_changed_callback (Schematic *schematic, char *new_title, SchematicView *sv);
@@ -929,6 +934,54 @@ static void zoom_cmd (GtkAction *action, GtkRadioAction *current, SchematicView 
 	zoom_check (sv);
 }
 
+/*
+ * Stretch the sheet horizontally.
+ */
+static void stretch_horizontal_cmd (GtkWidget *widget, SchematicView *sv)
+{
+	Schematic *sm;
+	guint width;
+
+	g_return_if_fail (sv != NULL);
+
+	sm = sv->priv->schematic;
+
+	g_return_if_fail (sm != NULL);
+	g_return_if_fail (IS_SCHEMATIC (sm));
+
+	width = schematic_get_width (sm);
+	schematic_set_width (sm, width * (1.0 + SCHEMATIC_STRETCH_FACTOR));
+
+	sheet_replace (sv);
+	schematic_view_reload (sv, sm);
+
+	gtk_widget_show_all (schematic_view_get_toplevel (sv));
+}
+
+/*
+ * Stretch the sheet vertically.
+ */
+static void stretch_vertical_cmd (GtkWidget *widget, SchematicView *sv)
+{
+	Schematic *sm;
+	guint height;
+
+	g_return_if_fail (sv != NULL);
+
+	sm = sv->priv->schematic;
+
+	g_return_if_fail (sm != NULL);
+	g_return_if_fail (IS_SCHEMATIC (sm));
+
+	height = schematic_get_height (sm);
+	schematic_set_height (sm, height * (1.0 + SCHEMATIC_STRETCH_FACTOR));
+
+	sheet_replace (sv);
+	schematic_view_reload (sv, sm);
+
+	gtk_widget_show_all (schematic_view_get_toplevel (sv));
+}
+
 static void simulate_cmd (GtkWidget *widget, SchematicView *sv)
 {
 	simulation_show_progress_bar (NULL, sv);
@@ -1025,9 +1078,9 @@ static void show_help (GtkWidget *widget, SchematicView *sv)
  * make the window occupy 3/4 of the screen with a padding of 50px in each
  * direction
  */
-static void set_window_size (SchematicView *sv)
+static void get_window_size (GdkRectangle *rect)
 {
-	// Set the window size to something reasonable
+	// Get a suitable value for the window size
 	GdkScreen *screen = gdk_screen_get_default ();
 	if (screen) {
 		//FIXME unused
@@ -1037,19 +1090,30 @@ static void set_window_size (SchematicView *sv)
 		// as the window is not realized yet (or for some other reason does not make
 		// a difference)
 		gint monitor = gdk_screen_get_primary_monitor (screen);
-		GdkRectangle rect;
-		gdk_screen_get_monitor_geometry (screen, monitor, &rect);
+		GdkRectangle monitor_rect;
+		gdk_screen_get_monitor_geometry (screen, monitor, &monitor_rect);
 
-		NG_DEBUG ("mon #%i %ix%i offset by %i,%i\n", monitor, rect.width, rect.height, rect.x,
-		          rect.y);
+		NG_DEBUG ("mon #%i %ix%i offset by %i,%i\n", monitor, monitor_rect.width, monitor_rect.height,
+		          monitor_rect.x, monitor_rect.y);
 
-		gtk_window_set_default_size (GTK_WINDOW (sv->toplevel), 3 * (rect.width - 50) / 4,
-		                             3 * (rect.height - 50) / 4);
+		rect->width = 3 * (monitor_rect.width - 50) / 4;
+		rect->height = 3 * (monitor_rect.height - 50) / 4;
 	} else {
 		g_warning ("No default screen found. Falling back to 1024x768 window size.");
-		gtk_window_set_default_size (GTK_WINDOW (sv->toplevel), 1024, 768);
+		rect->width = 1024;
+		rect->height = 768;
 	}
 }
+
+static void set_window_size (SchematicView *sv)
+{
+	GdkRectangle rect;
+
+	get_window_size (&rect);
+
+	gtk_window_set_default_size (GTK_WINDOW (sv->toplevel), rect.width, rect.height);
+}
+
 #include "schematic-view-menu.h"
 
 SchematicView *schematic_view_new (Schematic *schematic)
@@ -1069,6 +1133,7 @@ SchematicView *schematic_view_new (Schematic *schematic)
 	GtkPaned *paned;
 	GError *e = NULL;
 	GtkBuilder *builder;
+	GdkRectangle window_size;
 
 	g_return_val_if_fail (schematic, NULL);
 	g_return_val_if_fail (IS_SCHEMATIC (schematic), NULL);
@@ -1098,8 +1163,13 @@ SchematicView *schematic_view_new (Schematic *schematic)
 	paned = GTK_PANED (gtk_builder_get_object (builder, "paned"));
 	sv->priv->paned = paned;
 
-	// TODO make the size allocation dynamic - bug #45
-	sv->priv->sheet = SHEET (sheet_new (10000., 10000.));
+	get_window_size (&window_size);
+	if (schematic_get_width (schematic) < window_size.width)
+		schematic_set_width (schematic, window_size.width);
+	if (schematic_get_height (schematic) < window_size.height)
+		schematic_set_height (schematic, window_size.height);
+
+	sv->priv->sheet = SHEET (sheet_new ((double) schematic_get_width (schematic) + SHEET_BORDER, (double) schematic_get_height (schematic) + SHEET_BORDER));
 
 	g_signal_connect (G_OBJECT (sv->priv->sheet), "event", G_CALLBACK (sheet_event_callback),
 	                  sv->priv->sheet);
@@ -1161,7 +1231,6 @@ SchematicView *schematic_view_new (Schematic *schematic)
 	gtk_box_pack_start (GTK_BOX (vbox), hbox, TRUE, TRUE, 0);
 
 	gtk_paned_pack1 (paned, vbox, FALSE, TRUE);
-	gtk_window_set_focus (GTK_WINDOW (sv->toplevel), GTK_WIDGET (sv->priv->sheet));
 	gtk_widget_grab_focus (GTK_WIDGET (sv->priv->sheet));
 
 	g_signal_connect_after (G_OBJECT (sv->toplevel), "set_focus", G_CALLBACK (set_focus), sv);
@@ -1205,19 +1274,30 @@ SchematicView *schematic_view_new (Schematic *schematic)
 
 static void schematic_view_load (SchematicView *sv, Schematic *sm)
 {
-	GList *list;
-	g_return_if_fail (sv->priv->empty != FALSE);
-	g_return_if_fail (sm != NULL);
+	schematic_view_do_load (sv, sm, FALSE);
+}
 
-	if (sv->priv->schematic)
+static void schematic_view_do_load (SchematicView *sv, Schematic *sm, const gboolean reload)
+{
+	GList *list;
+	g_return_if_fail (sv != NULL);
+	g_return_if_fail (sm != NULL);
+	g_return_if_fail (IS_SCHEMATIC (sm));
+
+	if (!reload)
+		g_return_if_fail (sv->priv->empty != FALSE);
+
+	if (!reload && sv->priv->schematic)
 		g_object_unref (G_OBJECT (sv->priv->schematic));
 
 	sv->priv->schematic = sm;
 
-	g_signal_connect_object (G_OBJECT (sm), "title_changed", G_CALLBACK (title_changed_callback),
-	                         G_OBJECT (sv), 0);
-	g_signal_connect_object (G_OBJECT (sm), "item_data_added",
-	                         G_CALLBACK (item_data_added_callback), G_OBJECT (sv), 0);
+	if (!reload) {
+		g_signal_connect_object (G_OBJECT (sm), "title_changed", G_CALLBACK (title_changed_callback),
+					 G_OBJECT (sv), 0);
+		g_signal_connect_object (G_OBJECT (sm), "item_data_added",
+					 G_CALLBACK (item_data_added_callback), G_OBJECT (sv), 0);
+	}
 
 	list = schematic_get_items (sm);
 
@@ -1227,12 +1307,18 @@ static void schematic_view_load (SchematicView *sv, Schematic *sm)
 
 	sheet_connect_node_dots_to_signals (sv->priv->sheet);
 
-	//connect logview with logstore
-	log_view_set_store (LOG_VIEW (sv->priv->logview), schematic_get_log_store (sm));
+	// connect logview with logstore
+	if (!reload)
+		log_view_set_store (LOG_VIEW (sv->priv->logview), schematic_get_log_store (sm));
 
 	schematic_set_dirty (sm, FALSE);
 
 	g_list_free_full (list, g_object_unref);
+}
+
+static void schematic_view_reload (SchematicView *sv, Schematic *sm)
+{
+	schematic_view_do_load (sv, sm, TRUE);
 }
 
 static void item_selection_changed_callback (SheetItem *item, gboolean selected, SchematicView *sv)
@@ -1366,6 +1452,14 @@ Sheet *schematic_view_get_sheet (SchematicView *sv)
 	g_return_val_if_fail (IS_SCHEMATIC_VIEW (sv), NULL);
 
 	return sv->priv->sheet;
+}
+
+void schematic_view_set_sheet (SchematicView *sv, Sheet *sheet)
+{
+	g_return_if_fail (sv != NULL);
+	g_return_if_fail (IS_SCHEMATIC_VIEW (sv));
+
+	sv->priv->sheet = sheet;
 }
 
 Schematic *schematic_view_get_schematic (SchematicView *sv)

--- a/src/schematic-view.h
+++ b/src/schematic-view.h
@@ -7,12 +7,14 @@
  *  Ricardo Markiewicz <rmarkie@fi.uba.ar>
  *  Andres de Barbara <adebarbara@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
+ *  Guido Trentalancia <guido@trentalancia.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
  * Copyright (C) 1999-2001  Richard Hult
  * Copyright (C) 2003,2004  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
+ * Copyright (C) 2017       Guido Trentalancia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -41,6 +43,14 @@ typedef struct _SchematicView SchematicView;
 #include "schematic.h"
 #include "sheet.h"
 
+/*
+ * When stretching a schematic to resize
+ * it, increase its width or height of
+ * this percentage (the recommended factor
+ * is 0.15 for a 15% increase).
+ */
+#define	SCHEMATIC_STRETCH_FACTOR	0.15
+
 typedef enum { DRAG_URI_INFO, DRAG_PART_INFO } DragTypes;
 
 #define TYPE_SCHEMATIC_VIEW (schematic_view_get_type ())
@@ -57,6 +67,7 @@ typedef struct _SchematicViewPriv SchematicViewPriv;
 GType schematic_view_get_type (void);
 SchematicView *schematic_view_new (Schematic *schematic);
 Sheet *schematic_view_get_sheet (SchematicView *sv);
+void schematic_view_set_sheet (SchematicView *sv, Sheet *sheet);
 Schematic *schematic_view_get_schematic (SchematicView *sv);
 Schematic *schematic_view_get_schematic_from_sheet (Sheet *sheet);
 SchematicView *schematic_view_get_schematicview_from_sheet (Sheet *sheet);

--- a/src/sheet/part-item.c
+++ b/src/sheet/part-item.c
@@ -722,14 +722,6 @@ static void part_changed_callback (ItemData *data, SheetItem *sheet_item)
 	// no translations
 	inv.y0 = inv.x0 = 0.;
 
-	Sheet *sheet = SHEET (goo_canvas_item_get_canvas (GOO_CANVAS_ITEM (sheet_item)));
-	if (G_UNLIKELY (!sheet)) {
-		g_warning ("Failed to determine the Sheet the item is glued to. This should "
-		           "never happen. Ever!");
-	} else {
-		item_data_snap (data, sheet->grid); //&morph.x0, &morph.y0); //FIXME recheck
-		                                    // if this works as expected FIXME
-	}
 	goo_canvas_item_set_transform (GOO_CANVAS_ITEM (sheet_item), &(morph));
 
 	priv->cache_valid = FALSE;

--- a/src/sheet/sheet-item.c
+++ b/src/sheet/sheet-item.c
@@ -420,7 +420,6 @@ gboolean sheet_item_event (GooCanvasItem *sheet_item, GooCanvasItem *sheet_targe
 
 				item_data = SHEET_ITEM (list->data)->priv->data;
 				item_data_move (item_data, &delta);
-				item_data_snap (item_data, sheet->grid);
 				item_data_register (item_data);
 			}
 			break;
@@ -641,7 +640,6 @@ int sheet_item_floating_event (Sheet *sheet, const GdkEvent *event)
 				NG_DEBUG ("Item Data Pos will be %lf %lf", snapped.x, snapped.y)
 
 				item_data_set_pos (floating_data, &snapped);
-				item_data_snap (floating_data, sheet->grid);
 
 				schematic_add_item (schematic_view_get_schematic_from_sheet (sheet), floating_data);
 

--- a/src/sheet/sheet.c
+++ b/src/sheet/sheet.c
@@ -306,7 +306,7 @@ gboolean sheet_get_adjustments (const Sheet *sheet, GtkAdjustment **hadj, GtkAdj
 }
 
 /**
- * \brief change the zoom by factor
+ * \brief change the zoom by factor (zoom step)
  *
  * zoom origin when zooming in is the cursor
  * zoom origin when zooming out is the center of the current viewport
@@ -314,7 +314,7 @@ gboolean sheet_get_adjustments (const Sheet *sheet, GtkAdjustment **hadj, GtkAdj
  * @param sheet
  * @param factor values should be in the range of [0.5 .. 2]
  */
-void sheet_change_zoom (Sheet *sheet, gdouble factor)
+void sheet_zoom_step (Sheet *sheet, const gdouble factor)
 {
 	double zoom;
 	sheet_get_zoom (sheet, &zoom);
@@ -803,12 +803,12 @@ int sheet_event_callback (GtkWidget *widget, GdkEvent *event, Sheet *sheet)
 				double zoom;
 				sheet_get_zoom (sheet, &zoom);
 				if (zoom < ZOOM_MAX)
-					sheet_change_zoom (sheet, 1.1);
+					sheet_zoom_step (sheet, 1.1);
 			} else if (scr_event->direction == GDK_SCROLL_DOWN) {
 				double zoom;
 				sheet_get_zoom (sheet, &zoom);
 				if (zoom > ZOOM_MIN)
-					sheet_change_zoom (sheet, 0.9);
+					sheet_zoom_step (sheet, 0.9);
 			}
 		}
 	} break;

--- a/src/sheet/sheet.h
+++ b/src/sheet/sheet.h
@@ -96,7 +96,7 @@ gboolean sheet_replace (SchematicView *sv);
 void sheet_scroll_pixel (const Sheet *sheet, int dx, int dy);
 void sheet_get_size_pixels (const Sheet *sheet, guint *width, guint *height);
 gpointer sheet_get_first_selected_item (const Sheet *sheet);
-void sheet_change_zoom (Sheet *sheet, double rate);
+void sheet_zoom_step (Sheet *sheet, const double rate);
 void sheet_get_zoom (const Sheet *sheet, gdouble *zoom);
 void sheet_delete_selected_items (const Sheet *sheet);
 void sheet_rotate_selected_items (const Sheet *sheet);

--- a/src/sheet/sheet.h
+++ b/src/sheet/sheet.h
@@ -7,12 +7,14 @@
  *  Ricardo Markiewicz <rmarkie@fi.uba.ar>
  *  Andres de Barbara <adebarbara@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
+ *  Guido Trentalancia <guido@trentalancia.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
  * Copyright (C) 1999-2001  Richard Hult
  * Copyright (C) 2003,2004  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
+ * Copyright (C) 2017       Guido Trentalancia
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -39,6 +41,12 @@
 #include "grid.h"
 
 #include "item-data.h"
+
+// typedef to avoid circular dependency
+typedef struct _SchematicView SchematicView;
+
+// Allow about 200 pixels for the border of the sheet
+#define SHEET_BORDER    200
 
 typedef struct _Sheet Sheet;
 typedef struct _SheetPriv SheetPriv;
@@ -83,7 +91,8 @@ struct _SheetClass
 };
 
 GType sheet_get_type (void);
-GtkWidget *sheet_new (gdouble height, gdouble width);
+GtkWidget *sheet_new (const gdouble width, const gdouble height);
+void sheet_replace (SchematicView *sv);
 void sheet_scroll_pixel (const Sheet *sheet, int dx, int dy);
 void sheet_get_size_pixels (const Sheet *sheet, guint *width, guint *height);
 gpointer sheet_get_first_selected_item (const Sheet *sheet);

--- a/src/sheet/sheet.h
+++ b/src/sheet/sheet.h
@@ -92,7 +92,7 @@ struct _SheetClass
 
 GType sheet_get_type (void);
 GtkWidget *sheet_new (const gdouble width, const gdouble height);
-void sheet_replace (SchematicView *sv);
+gboolean sheet_replace (SchematicView *sv);
 void sheet_scroll_pixel (const Sheet *sheet, int dx, int dy);
 void sheet_get_size_pixels (const Sheet *sheet, guint *width, guint *height);
 gpointer sheet_get_first_selected_item (const Sheet *sheet);

--- a/src/sheet/wire-item.c
+++ b/src/sheet/wire-item.c
@@ -741,14 +741,6 @@ static void wire_changed_callback (Wire *wire, WireItem *item)
 
 	wire_get_pos_and_length (wire, &start_pos, &length);
 
-	Sheet *sheet = SHEET (goo_canvas_item_get_canvas (GOO_CANVAS_ITEM (item)));
-	if (G_UNLIKELY (!sheet)) {
-		g_warning ("Failed to determine the Sheet the item is glued to. This should "
-		           "never happen. Ever!");
-	} else {
-		item_data_snap (ITEM_DATA (wire), sheet->grid);
-	}
-
 	// Move the canvas item and invalidate the bbox cache.
 	goo_canvas_item_set_simple_transform (GOO_CANVAS_ITEM (item), start_pos.x, start_pos.y, 1.0,
 	                                      0.0);

--- a/src/sim-settings.c
+++ b/src/sim-settings.c
@@ -198,19 +198,19 @@ gboolean sim_settings_get_trans_analyze_all (const SimSettings *sim_settings)
 gdouble sim_settings_get_trans_start (const SimSettings *sim_settings)
 {
 	gchar *text = sim_settings->trans_start;
-	return oregano_strtod (text, 's');
+	return oregano_strtod (text, "s");
 }
 
 gdouble sim_settings_get_trans_stop (const SimSettings *sim_settings)
 {
 	gchar *text = sim_settings->trans_stop;
-	return oregano_strtod (text, 's');
+	return oregano_strtod (text, "s");
 }
 
 gdouble sim_settings_get_trans_step (const SimSettings *sim_settings)
 {
 	gchar *text = sim_settings->trans_step;
-	return oregano_strtod (text, 's');
+	return oregano_strtod (text, "s");
 }
 
 gdouble sim_settings_get_trans_step_enable (const SimSettings *sim_settings)
@@ -272,12 +272,12 @@ gint sim_settings_get_ac_npoints (const SimSettings *sim_settings)
 
 gdouble sim_settings_get_ac_start (const SimSettings *sim_settings)
 {
-	return oregano_strtod (sim_settings->ac_start, 'Hz');
+	return oregano_strtod (sim_settings->ac_start, "Hz");
 }
 
 gdouble sim_settings_get_ac_stop (const SimSettings *sim_settings)
 {
-	return oregano_strtod (sim_settings->ac_stop, 'Hz');
+	return oregano_strtod (sim_settings->ac_stop, "Hz");
 }
 
 void sim_settings_set_ac (SimSettings *sim_settings, gboolean enable)
@@ -323,17 +323,17 @@ gchar *sim_settings_get_dc_vout (const SimSettings *sim_settings) { return sim_s
 
 gdouble sim_settings_get_dc_start (const SimSettings *sim_settings)
 {
-	return oregano_strtod (sim_settings->dc_start, 'V');
+	return oregano_strtod (sim_settings->dc_start, "V");
 }
 
 gdouble sim_settings_get_dc_stop (const SimSettings *sim_settings)
 {
-	return oregano_strtod (sim_settings->dc_stop, 'V');
+	return oregano_strtod (sim_settings->dc_stop, "V");
 }
 
 gdouble sim_settings_get_dc_step (const SimSettings *sim_settings)
 {
-	return oregano_strtod (sim_settings->dc_step, 'V');
+	return oregano_strtod (sim_settings->dc_step, "V");
 }
 
 void sim_settings_set_dc (SimSettings *sim_settings, gboolean enable)
@@ -458,12 +458,12 @@ gint sim_settings_get_noise_npoints (const SimSettings *sim_settings)
 
 gdouble sim_settings_get_noise_start (const SimSettings *sim_settings)
 {
-	return oregano_strtod (sim_settings->noise_start, 'Hz');
+	return oregano_strtod (sim_settings->noise_start, "Hz");
 }
 
 gdouble sim_settings_get_noise_stop (const SimSettings *sim_settings)
 {
-	return oregano_strtod (sim_settings->noise_stop, 'Hz');
+	return oregano_strtod (sim_settings->noise_stop, "Hz");
 }
 
 void sim_settings_set_noise (SimSettings *sim_settings, gboolean enable)

--- a/src/simulation.h
+++ b/src/simulation.h
@@ -50,6 +50,7 @@ typedef enum {
 	ANALYSIS_TYPE_AC,
 	ANALYSIS_TYPE_TRANSFER,
 	ANALYSIS_TYPE_DISTORTION,
+	ANALYSIS_TYPE_INTEGRATED_NOISE,
 	ANALYSIS_TYPE_NOISE,
 	ANALYSIS_TYPE_POLE_ZERO,
 	ANALYSIS_TYPE_SENSITIVITY,
@@ -127,6 +128,14 @@ typedef struct
 	double start, stop, step;
 } SimDC;
 
+typedef struct
+{
+	SimulationData sim_data;
+	int state;
+	double sim_length;
+	double start, stop;
+} SimNoise;
+
 typedef union
 {
 	SimOp op;
@@ -134,6 +143,7 @@ typedef union
 	SimFourier fourier;
 	SimAC ac;
 	SimDC dc;
+	SimNoise noise;
 } Analysis;
 
 void simulation_show_progress_bar (GtkWidget *widget, SchematicView *sv);

--- a/wscript
+++ b/wscript
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 # encoding: utf-8
 
-VERSION = '0.84.6'
+VERSION = '0.84.7'
 APPNAME = 'oregano'
 
 top = '.'


### PR DESCRIPTION
This commit fixes the following issue:

https://github.com/drahnr/oregano/issues/45

by dynamically determining the sheet size from the
schematic.

Please note that this triggers the following warning
in sheet/wire-item.c:

"Failed to determine the Sheet the item is glued to"

and although there are no visible consequences, it would
be preferable to look into this.

Also, sometimes after resizing the sheet scrollbar becomes
invisible for a while (probably on large dimensions).