### PR TITLE
Close #212 and check for NULL pointer in wire rotation function

### DIFF
--- a/src/model/wire.c
+++ b/src/model/wire.c
@@ -341,6 +341,7 @@ static void wire_rotate (ItemData *data, int angle, Coords *center_pos)
 
 	g_return_if_fail (data != NULL);
 	g_return_if_fail (IS_WIRE (data));
+	g_return_if_fail (center_pos != NULL);
 
 	if (angle == 0)
 		return;

--- a/src/schematic-view.c
+++ b/src/schematic-view.c
@@ -1087,8 +1087,12 @@ static void show_help (GtkWidget *widget, SchematicView *sv)
 {
 	GError *e = NULL;
 
+#if GTK_CHECK_VERSION (3,22,0)
 	if (!gtk_show_uri_on_window (GTK_WINDOW (sv->toplevel), "ghelp:oregano", gtk_get_current_event_time (),
-	                   &e)) {
+#else
+	if (!gtk_show_uri (gtk_widget_get_screen (sv->toplevel), "ghelp:oregano", gtk_get_current_event_time (),
+#endif
+     				&e)) {
 		NG_DEBUG ("Error %s\n", e->message);
 		g_clear_error (&e);
 	}


### PR DESCRIPTION
Minor improvements to close #212 and to check for NULL pointer in the wire rotation function.