### PR TITLE
Gnucap parser and splash screen fix

### DIFF
--- a/data/settings/io.ahoi.oregano.gschema.xml
+++ b/data/settings/io.ahoi.oregano.gschema.xml
@@ -3,7 +3,7 @@
 	<schema path="/io/ahoi/oregano/" id="io.ahoi.oregano" gettext-domain="oregano">
 		<key type="i" name="engine">
 			<default>1</default>
-			<summary>The spice engine ngspice or gnucap.</summary>
+			<summary>The spice engine: gnucap, spice3 or ngspice.</summary>
 		</key>
 		<key type="b" name="compress-files">
 			<default>false</default>

--- a/data/settings/io.ahoi.oregano.gschema.xml
+++ b/data/settings/io.ahoi.oregano.gschema.xml
@@ -14,7 +14,7 @@
 			<summary>oregano provides a log window by default.</summary>
 		</key>
 		<key type="b" name="show-splash">
-			<default>false</default>
+			<default>true</default>
 			<summary>oregano starts providing a splash window at startup.</summary>
 		</key>
 	</schema>

--- a/data/wscript
+++ b/data/wscript
@@ -23,6 +23,7 @@ def build(bld):
 		bld.install_as ('${DATADIR}/mime-info/oregano.keys', 'mime/oregano.keys.in')
 		bld.install_files ('${DATADIR}/icons/hicolor/48x48/apps/', 'mime/oregano.png')
 		bld.install_files ('${DATADIR}/icons/hicolor/scalable/apps/', 'mime/oregano.svg')
+		bld.install_files ('${DATADIR}/oregano/ui/', 'xml/splash.xpm')
 		#things we need to be known by the app are already defined and stored in the main wscript
 		bld.install_files (bld.env.path_lang, 'netlist.lang')
 		bld.install_files (bld.env.path_model, bld.path.ant_glob('models/*.model'))

--- a/src/engines/gnucap.c
+++ b/src/engines/gnucap.c
@@ -578,7 +578,6 @@ static void gnucap_parse (gchar *raw, gint len, OreganoGnuCap *gnucap)
 		// Got a complete line
 		s = buf;
 		NG_DEBUG ("%s", s);
-		state = STATE_IDLE;
 		if (s[0] == GNUCAP_TITLE) {
 			SimSettings *sim_settings;
 			gdouble np1;

--- a/src/model/schematic.c
+++ b/src/model/schematic.c
@@ -528,7 +528,7 @@ void schematic_log_append_error (Schematic *schematic, const char *message)
 
 	priv = schematic->priv;
 
-	log_append (schematic->priv->logstore, "ngspice Error", message);
+	log_append (schematic->priv->logstore, "simulation engine Error", message);
 
 	// LEGACY
 	gtk_text_buffer_get_end_iter (priv->log, &iter);

--- a/src/splash.c
+++ b/src/splash.c
@@ -66,6 +66,7 @@ Splash *oregano_splash_new (GError **error)
 	sp->can_destroy = FALSE;
 
 	sp->win = GTK_WINDOW (gtk_builder_get_object (gui, "splash"));
+	gtk_window_set_keep_above (sp->win, TRUE);
 	sp->lbl = GTK_LABEL (gtk_builder_get_object (gui, "label"));
 	sp->progress = GTK_WIDGET (gtk_builder_get_object (gui, "pbar"));
 

--- a/wscript
+++ b/wscript
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 # encoding: utf-8
 
-VERSION = '0.84.9'
+VERSION = '0.84.10'
 APPNAME = 'oregano'
 
 top = '.'


### PR DESCRIPTION
Install the default splash screen image, set the splash screen window on top of other windows and fix an error message text.