### PR TITLE
Avoid an invalid memory free operation with the gnucap engine

### DIFF
--- a/src/engines/gnucap.c
+++ b/src/engines/gnucap.c
@@ -422,7 +422,7 @@ static gchar *gnucap_get_operation (OreganoEngine *self)
 	OreganoGnuCapPriv *priv = OREGANO_GNUCAP (self)->priv;
 
 	if (priv->current == NULL)
-		return _ ("None");
+		return g_strdup(_("None"));
 
 	return oregano_engine_get_analysis_name (priv->current);
 }


### PR DESCRIPTION
Duplicate the string returned for "no operation" when returning the current simulation state.

This avoids freeing an invalid memory chunk in the progress bar timeout callback function (might solve #217 ?)
