### PR TITLE
New features: undo and redo historial

### DIFF
--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -33,6 +33,7 @@
 #include <glib.h>
 
 #include "oregano.h"
+#include "sheet.h"
 #include "sheet-item.h"
 #include "clipboard.h"
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -4,10 +4,12 @@
  *
  * Authors:
  *  Bernhard Schuster <bernhard@ahoi.io>
+ *  Daniel Dwek <todovirtual15@gmail.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
  * Copyright (C) 2012-2013  Bernhard Schuster
+ * Copyright (C) 2022-2023  Daniel Dwek
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -43,3 +45,27 @@
 			          ##__VA_ARGS__);                                                              \
 		}                                                                                          \
 	}
+
+#define color_black		"\033[00;30m"
+#define color_red		"\033[00;31m"
+#define color_green		"\033[00;32m"
+#define color_orange		"\033[00;33m"
+#define color_blue		"\033[00;34m"
+#define color_magenta		"\033[00;35m"
+#define color_cyan		"\033[00;36m"
+#define color_lightgray		"\033[00;37m"
+#define color_darkgray		"\033[01;30m"
+#define color_lightred		"\033[01;31m"
+#define color_lightgreen	"\033[01;32m"
+#define color_yellow		"\033[01;33m"
+#define color_lightblue		"\033[01;34m"
+#define color_lightmagenta	"\033[01;35m"
+#define color_lightcyan		"\033[01;36m"
+#define color_white		"\033[01;37m"
+
+#define color_restore		"\033[00m"
+
+#define COLOR_SHEETITEM		color_blue
+#define COLOR_COORDS		color_green
+#define COLOR_CENTER		color_red
+#define COLOR_NORMAL		color_restore

--- a/src/engines/gnucap.c
+++ b/src/engines/gnucap.c
@@ -231,7 +231,7 @@ static gboolean gnucap_generate_netlist (OreganoEngine *engine, const gchar *fil
 	for (iter = output.models; iter; iter = iter->next) {
 		gchar *model;
 		model = (gchar *)iter->data;
-		g_fprintf (file, ".include %s/%s.model\n", OREGANO_MODELDIR, model);
+		g_fprintf (file, ".include %s%s.model\n", OREGANO_MODELDIR, model);
 	}
 
 	// Prints template parts

--- a/src/load-library.h
+++ b/src/load-library.h
@@ -53,7 +53,6 @@ typedef enum { SYMBOL_OBJECT_LINE, SYMBOL_OBJECT_ARC, SYMBOL_OBJECT_TEXT } Symbo
 struct _SymbolObject
 {
 	SymbolObjectType type;
-
 	union
 	{
 		struct
@@ -79,5 +78,4 @@ struct _SymbolObject
 Library *library_parse_xml_file (const gchar *filename);
 LibrarySymbol *library_get_symbol (const gchar *symbol_name);
 LibraryPart *library_get_part (Library *library, const gchar *part_name);
-
 #endif

--- a/src/load-schematic.c
+++ b/src/load-schematic.c
@@ -9,6 +9,7 @@
  *  Marc Lorber <lorber.marc@wanadoo.fr>
  *  Bernhard Schuster <bernhard@ahoi.io>
  *  Guido Trentalancia <guido@trentalancia.com>
+ *  Daniel Dwek <todovirtual15@gmail.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
@@ -17,6 +18,7 @@
  * Copyright (C) 2009-2012  Marc Lorber
  * Copyright (C) 2013-2014  Bernhard Schuster
  * Copyright (C) 2017       Guido Trentalancia
+ * Copyright (C) 2022-2023  Daniel Dwek
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -50,6 +52,7 @@
 #include "errors.h"
 #include "engines/netlist-helper.h"
 
+#include "part-private.h"
 #include "debug.h"
 
 typedef enum {
@@ -219,7 +222,7 @@ static void create_textbox (ParseState *state)
 
 	textbox = textbox_new (NULL);
 	textbox_set_text (textbox, state->textbox_text);
-	item_data_set_pos (ITEM_DATA (textbox), &state->pos);
+	item_data_set_pos (ITEM_DATA (textbox), &state->pos, EMIT_SIGNAL_CHANGED);
 	schematic_add_item (state->schematic, ITEM_DATA (textbox));
 }
 
@@ -236,7 +239,7 @@ static void create_wire (ParseState *state)
 	wire = wire_new ();
 	wire_set_length (wire, &length);
 
-	item_data_set_pos (ITEM_DATA (wire), &state->wire_start);
+	item_data_set_pos (ITEM_DATA (wire), &state->wire_start, EMIT_SIGNAL_CHANGED);
 	schematic_add_item (state->schematic, ITEM_DATA (wire));
 }
 
@@ -251,13 +254,7 @@ static void create_part (ParseState *state)
 		return;
 	}
 
-	item_data_set_pos (ITEM_DATA (part), &state->pos);
-	item_data_rotate (ITEM_DATA (part), state->rotation, NULL);
-	if (state->flip & ID_FLIP_HORIZ)
-		item_data_flip (ITEM_DATA (part), ID_FLIP_HORIZ, NULL);
-	if (state->flip & ID_FLIP_VERT)
-		item_data_flip (ITEM_DATA (part), ID_FLIP_VERT, NULL);
-
+	item_data_set_pos (ITEM_DATA (part), &state->pos, EMIT_SIGNAL_MOVED | EMIT_SIGNAL_CHANGED);
 	schematic_add_item (state->schematic, ITEM_DATA (part));
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -7,12 +7,14 @@
  *  Ricardo Markiewicz <rmarkie@fi.uba.ar>
  *  Andres de Barbara <adebarbara@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
+ *  Daniel Dwek <todovirtual15@gmail.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
  * Copyright (C) 1999-2001  Richard Hult
  * Copyright (C) 2003,2006  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
+ * Copyright (C) 2022-2023  Daniel Dwek
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -39,6 +41,8 @@
 #include "oregano.h"
 #include "options.h"
 #include "schematic.h"
+
+#include "stack.h"
 
 int main (int argc, char *argv[])
 {
@@ -74,6 +78,14 @@ int main (int argc, char *argv[])
 
 	// required?
 	gtk_init (&argc, &argv);
+
+	undo_stack = (historial_stack_t *) calloc (1, sizeof (historial_stack_t));
+	if (!undo_stack)
+		return 1;
+
+	redo_stack = (historial_stack_t *) calloc (1, sizeof (historial_stack_t));
+	if (!redo_stack)
+		return 1;
 
 	// required, as we possibly need signal
 	// information within oregano.c _before_ the

--- a/src/model/node-store-private.h
+++ b/src/model/node-store-private.h
@@ -336,7 +336,7 @@ static Wire *vulcanize_wire (NodeStore *store, Wire *a, Wire *b)
 #else
 	Wire *w = a;
 #endif
-	item_data_set_pos (ITEM_DATA (w), &start);
+	item_data_set_pos (ITEM_DATA (w), &start, EMIT_SIGNAL_CHANGED);
 	wire_set_length (w, &len);
 
 	for (list = wire_get_nodes (b); list;) {

--- a/src/model/node-store.h
+++ b/src/model/node-store.h
@@ -37,6 +37,11 @@
 #include <glib.h>
 #include <glib-object.h>
 
+typedef struct _NodeStore NodeStore;
+typedef struct _NodeStoreClass NodeStoreClass;
+typedef struct _NodeRect NodeRect;
+
+#include "item-data.h"
 #include "coords.h"
 
 #define TYPE_NODE_STORE node_store_get_type ()
@@ -45,10 +50,6 @@
 #define IS_NODE_STORE(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TYPE_NODE_STORE))
 #define NODE_STORE_GET_CLASS(obj)                                                                  \
 	(G_TYPE_INSTANCE_GET_CLASS ((obj), TYPE_NODE_STORE, NodeStoreClass))
-
-typedef struct _NodeStore NodeStore;
-typedef struct _NodeStoreClass NodeStoreClass;
-typedef struct _NodeRect NodeRect;
 
 #include "schematic-print-context.h"
 #include "node.h"

--- a/src/model/node.h
+++ b/src/model/node.h
@@ -32,21 +32,19 @@
 #ifndef __NODE_H
 #define __NODE_H
 
-#include <gtk/gtk.h>
+typedef struct _Node Node;
+typedef struct _NodeClass NodeClass;
 
-#include "coords.h"
+#include <gtk/gtk.h>
 #include "part.h"
+#include "coords.h"
+#include "wire.h"
 
 #define TYPE_NODE (node_get_type ())
 #define NODE(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), TYPE_NODE, Node))
 #define NODE_CLASS(klass) (G_TYPE_CHECK_CLASS_CAST ((klass), TYPE_NODE, NodeClass))
 #define IS_NODE(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TYPE_NODE))
 #define IS_NODE_CLASS(klass) (G_TYPE_INSTANCE_GET_CLASS ((klass), TYPE_NODE, NodeClass))
-
-typedef struct _Node Node;
-typedef struct _NodeClass NodeClass;
-
-#include "wire.h"
 
 struct _Node
 {

--- a/src/model/part-private.h
+++ b/src/model/part-private.h
@@ -40,8 +40,9 @@
 struct _PartPriv
 {
 	guint16 num_pins : 16;
-	//	guint16	 rotation : 16;
+	guint16	 rotation : 16;
 	IDFlip flip : 8;
+	gboolean create : 8;
 
 	gchar *name;
 	GSList *properties;

--- a/src/model/part.h
+++ b/src/model/part.h
@@ -8,6 +8,7 @@
  *  Andres de Barbara <adebarbara@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
  *  Bernhard Schuster <bernhard@ahoi.io>
+ *  Daniel Dwek <todovirtual15@gmail.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
@@ -15,6 +16,7 @@
  * Copyright (C) 2003,2004  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
  * Copyright (C) 2013-2014  Bernhard Schuster
+ * Copyright (C) 2022-2023  Daniel Dwek
  *
  *
  * This program is free software; you can redistribute it and/or
@@ -36,8 +38,13 @@
 #ifndef __PART_H
 #define __PART_H
 
-#include <gtk/gtk.h>
+typedef struct _Part Part;
+typedef struct _PartClass PartClass;
+typedef struct _Pin Pin;
+typedef struct _PartPriv PartPriv;
 
+#include <gtk/gtk.h>
+#include "item-data.h"
 #include "coords.h"
 #include "clipboard.h"
 #include "load-common.h"
@@ -47,13 +54,6 @@
 #define PART_CLASS(klass) (G_TYPE_CHECK_CLASS_CAST ((klass), TYPE_PART, PartClass))
 #define IS_PART(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TYPE_PART))
 #define IS_PART_CLASS(klass) (G_TYPE_INSTANCE_GET_CLASS ((klass), TYPE_PART, PartClass))
-
-typedef struct _Part Part;
-typedef struct _PartClass PartClass;
-typedef struct _Pin Pin;
-typedef struct _PartPriv PartPriv;
-
-#include "item-data.h"
 
 struct _Pin
 {
@@ -77,6 +77,15 @@ struct _PartClass
 
 	void (*changed)();
 };
+
+typedef struct callback_params_st {
+	SheetItem *s_item;
+	Coords center;
+	gint angle;
+	Coords *bbox1;
+	Coords *bbox2;
+	gint group;
+} callback_params_t;
 
 GType part_get_type (void);
 Part *part_new ();

--- a/src/model/textbox.c
+++ b/src/model/textbox.c
@@ -7,12 +7,14 @@
  *  Ricardo Markiewicz <rmarkie@fi.uba.ar>
  *  Andres de Barbara <adebarbara@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
+ *  Daniel Dwek <todovirtual15@gmail.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
  * Copyright (C) 1999-2001  Richard Hult
  * Copyright (C) 2003,2006  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
+ * Copyright (C) 2022-2023  Daniel Dwek
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -46,13 +48,12 @@ static void textbox_class_init (TextboxClass *klass);
 static void textbox_init (Textbox *textbox);
 static void textbox_copy (ItemData *dest, ItemData *src);
 static ItemData *textbox_clone (ItemData *src);
-static void textbox_rotate (ItemData *data, int angle, Coords *center);
+static void textbox_rotate (ItemData *data, gint angle, Coords *center, Coords *bbox1, Coords *bbox2, const char *caller_fn);
+static void textbox_flip (ItemData *data, IDFlip direction, Coords *center);
 static void textbox_print (ItemData *data, cairo_t *cr, SchematicPrintContext *ctx);
 static int textbox_register (ItemData *data);
 static void textbox_unregister (ItemData *data);
 static gboolean textbox_has_properties (ItemData *data);
-
-static void textbox_flip (ItemData *data, IDFlip direction, Coords *center);
 
 enum { TEXT_CHANGED, FONT_CHANGED, LAST_SIGNAL };
 
@@ -168,7 +169,7 @@ static void textbox_copy (ItemData *dest, ItemData *src)
 	dest_textbox->priv->font = src_textbox->priv->font;
 }
 
-static void textbox_rotate (ItemData *data, int angle, Coords *center)
+static void textbox_rotate (ItemData *data, gint angle, Coords *center, Coords *bbox1, Coords *bbox2, const char *caller_fn)
 {
 	cairo_matrix_t affine;
 	double x, y;
@@ -178,6 +179,9 @@ static void textbox_rotate (ItemData *data, int angle, Coords *center)
 
 	g_return_if_fail (data != NULL);
 	g_return_if_fail (IS_TEXTBOX (data));
+	g_return_if_fail (center != NULL);
+	g_return_if_fail (bbox1 != NULL);
+	g_return_if_fail (bbox2 != NULL);
 
 	if (angle == 0)
 		return;
@@ -219,8 +223,7 @@ static void textbox_flip (ItemData *data, IDFlip direction, Coords *center)
 	Coords b1, b2;
 	Coords textbox_center = {0.0, 0.0}, delta;
 
-	g_return_if_fail (data != NULL);
-	g_return_if_fail (IS_TEXTBOX (data));
+//	g_return_if_fail (objs != NULL);
 
 	textbox = TEXTBOX (data);
 

--- a/src/model/textbox.h
+++ b/src/model/textbox.h
@@ -7,12 +7,14 @@
  *  Ricardo Markiewicz <rmarkie@fi.uba.ar>
  *  Andres de Barbara <adebarbara@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
+ *  Daniel Dwek <todovirtual15@gmail.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
  * Copyright (C) 1999-2001  Richard Hult
  * Copyright (C) 2003,2004  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
+ * Copyright (C) 2022-2023  Daniel Dwek
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -35,6 +37,10 @@
 
 #include <gtk/gtk.h>
 
+typedef struct _Textbox Textbox;
+typedef struct _TextboxClass TextboxClass;
+typedef struct _TextboxPriv TextboxPriv;
+
 #include "clipboard.h"
 #include "item-data.h"
 
@@ -44,13 +50,9 @@
 #define IS_TEXTBOX(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TYPE_TEXTBOX))
 #define IS_TEXTBOX_CLASS(klass) (G_TYPE_CHECK_GET_CLASS ((klass), TYPE_TEXTBOX))
 
-typedef struct _Textbox Textbox;
-typedef struct _TextboxClass TextboxClass;
-typedef struct _TextboxPriv TextboxPriv;
-
 struct _Textbox
 {
-	ItemData parent;
+	ItemData *parent;
 	TextboxPriv *priv;
 	gulong text_changed_handler_id;
 	gulong font_changed_handler_id;
@@ -58,7 +60,7 @@ struct _Textbox
 
 struct _TextboxClass
 {
-	ItemDataClass parent_class;
+	ItemDataClass *parent_class;
 	Textbox *(*dup)(Textbox *textbox);
 };
 

--- a/src/model/wire.h
+++ b/src/model/wire.h
@@ -8,6 +8,7 @@
  *  Andres de Barbara <adebarbara@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
  *  Bernhard Schuster <bernhard@ahoi.io>
+ *  Daniel Dwek <todovirtual15@gmail.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
@@ -15,6 +16,7 @@
  * Copyright (C) 2003,2004  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
  * Copyright (C) 2013-2014  Bernhard Schuster
+ * Copyright (C) 2022-2023  Daniel Dwek
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -35,7 +37,22 @@
 #ifndef __WIRE_H
 #define __WIRE_H
 
+typedef struct _Wire Wire;
+typedef struct _WireClass WireClass;
+typedef struct _WirePriv WirePriv;
+
+typedef enum {
+	WIRE_DIR_NONE = 0,
+	WIRE_DIR_HORIZ = 1,
+	WIRE_DIR_VERT = 2,
+	WIRE_DIR_DIAG = 3
+} WireDir;
+
 #include <gtk/gtk.h>
+#include "item-data.h"
+#include "node-store.h"
+#include "node.h"
+#include "grid.h"
 
 #include "coords.h"
 #include "clipboard.h"
@@ -45,21 +62,6 @@
 #define WIRE_CLASS(klass) (G_TYPE_CHECK_CLASS_CAST ((klass), TYPE_WIRE, WireClass))
 #define IS_WIRE(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TYPE_WIRE))
 #define IS_WIRE_CLASS(klass) (G_TYPE_INSTANCE_GET_CLASS ((klass), TYPE_WIRE))
-
-typedef struct _Wire Wire;
-typedef struct _WireClass WireClass;
-typedef struct _WirePriv WirePriv;
-
-#include "node-store.h"
-#include "node.h"
-#include "grid.h"
-
-typedef enum {
-	WIRE_DIR_NONE = 0,
-	WIRE_DIR_HORIZ = 1,
-	WIRE_DIR_VERT = 2,
-	WIRE_DIR_DIAG = 3
-} WireDir;
 
 struct _Wire
 {
@@ -77,7 +79,7 @@ struct _WireClass
 };
 
 GType wire_get_type (void);
-Wire *wire_new ();
+Wire *wire_new (void);
 NodeStore *wire_get_store (Wire *wire);
 gint wire_set_store (Wire *wire, NodeStore *store);
 gint wire_add_node (Wire *wire, Node *node);

--- a/src/options.c
+++ b/src/options.c
@@ -45,15 +45,15 @@ gboolean oregano_options_parse (int *argc, char **argv[], GError **e)
 }
 
 
-inline gboolean oregano_options_version () { return opts.version; }
+gboolean oregano_options_version () { return opts.version; }
 
-inline gboolean oregano_options_debug_wires () { return opts.debug.wires || opts.debug.all; }
+gboolean oregano_options_debug_wires () { return opts.debug.wires || opts.debug.all; }
 
-inline gboolean oregano_options_debug_boxes () { return opts.debug.boxes || opts.debug.all; }
+gboolean oregano_options_debug_boxes () { return opts.debug.boxes || opts.debug.all; }
 
-inline gboolean oregano_options_debug_dots () { return opts.debug.dots || opts.debug.all; }
+gboolean oregano_options_debug_dots () { return opts.debug.dots || opts.debug.all; }
 
-inline gboolean oregano_options_debug_directions ()
+gboolean oregano_options_debug_directions ()
 {
 	return opts.debug.directions || opts.debug.all;
 }

--- a/src/part-browser.c
+++ b/src/part-browser.c
@@ -8,6 +8,7 @@
  *  Andres de Barbara <adebarbara@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
  *  Bernhard Schuster <bernhard@ahoi.io>
+ *  Daniel Dwek <todovirtual15@gmail.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
@@ -15,6 +16,7 @@
  * Copyright (C) 2003,2006  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
  * Copyright (C) 2013       Bernhard Schuster
+ * Copyright (C) 2022-2023  Daniel Dwek
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -184,7 +186,7 @@ static void place_cmd (GtkWidget *widget, Browser *br)
 	}
 
 	pos.x = pos.y = 0;
-	item_data_set_pos (ITEM_DATA (part), &pos);
+	item_data_set_pos (ITEM_DATA (part), &pos, EMIT_SIGNAL_MOVED);
 	sheet_connect_part_item_to_floating_group (sheet, (gpointer)br->schematic_view);
 
 	sheet_select_all (sheet, FALSE);
@@ -375,7 +377,7 @@ void part_browser_dnd (GtkSelectionData *selection_data, int x, int y)
 		return;
 	}
 
-	item_data_set_pos (ITEM_DATA (part), &pos);
+	item_data_set_pos (ITEM_DATA (part), &pos, EMIT_SIGNAL_CREATED);
 	sheet_connect_part_item_to_floating_group (sheet, (gpointer)data->schematic_view);
 
 	sheet_select_all (sheet, FALSE);

--- a/src/schematic-view-menu.h
+++ b/src/schematic-view-menu.h
@@ -8,6 +8,7 @@
  *  Andres de Barbara <adebarbara@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
  *  Guido Trentalancia <guido@trentalancia.com>
+ *  Daniel Dwek <todovirtual15@gmail.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
@@ -15,6 +16,7 @@
  * Copyright (C) 2003,2006  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
  * Copyright (C) 2017       Guido Trentalancia
+ * Copyright (C) 2022-2023  Daniel Dwek
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -66,8 +68,9 @@ static GtkActionEntry entries[] = {
     {"Export", NULL, N_ ("_Export..."), NULL, N_ ("Export schematic"), G_CALLBACK (export_cmd)},
     {"Close", GTK_STOCK_CLOSE, N_ ("_Close"), "<control>W", N_ ("Close the current schematic"),
      G_CALLBACK (close_cmd)},
-    {"Quit", GTK_STOCK_QUIT, N_ ("_Quit"), "<control>Q", N_ ("Close all schematics"),
-     G_CALLBACK (quit_cmd)},
+    {"Quit", GTK_STOCK_QUIT, N_ ("_Quit"), "<control>Q", N_ ("Close all schematics"), G_CALLBACK (quit_cmd)},
+    {"Undo", GTK_STOCK_UNDO, N_ ("_Undo"), "<control>Z", N_ ("Undo last action"), G_CALLBACK (undo_cmd)},
+    {"Redo", GTK_STOCK_REDO, N_ ("_Redo"), "<control><shift>Z", N_ ("Redo actions undone in reverse order"), G_CALLBACK (redo_cmd)},
     {"Cut", GTK_STOCK_CUT, N_ ("C_ut"), "<control>X", NULL, G_CALLBACK (cut_cmd)},
     {"Copy", GTK_STOCK_COPY, N_ ("_Copy"), "<control>C", NULL, G_CALLBACK (copy_cmd)},
     {"Paste", GTK_STOCK_PASTE, N_ ("_Paste"), "<control>V", NULL, G_CALLBACK (paste_cmd)},
@@ -160,6 +163,8 @@ static const char *ui_description = "<ui>"
                                     "      <menuitem action='Quit'/>"
                                     "    </menu>"
                                     "    <menu action='MenuEdit'>"
+				    "      <menuitem action='Undo'/>"
+                                    "      <menuitem action='Redo'/>"
                                     "      <menuitem action='Cut'/>"
                                     "      <menuitem action='Copy'/>"
                                     "      <menuitem action='Paste'/>"
@@ -207,6 +212,8 @@ static const char *ui_description = "<ui>"
                                     "    <toolitem action='Open'/>"
                                     "    <toolitem action='Save'/>"
                                     "    <separator/>"
+                                    "    <toolitem action='Undo'/>"
+                                    "    <toolitem action='Redo'/>"
                                     "    <toolitem action='Cut'/>"
                                     "    <toolitem action='Copy'/>"
                                     "    <toolitem action='Paste'/>"

--- a/src/schematic-view.h
+++ b/src/schematic-view.h
@@ -8,6 +8,7 @@
  *  Andres de Barbara <adebarbara@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
  *  Guido Trentalancia <guido@trentalancia.com>
+ *  Daniel Dwek <todovirtual15@gmail.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
@@ -15,6 +16,7 @@
  * Copyright (C) 2003,2004  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
  * Copyright (C) 2017       Guido Trentalancia
+ * Copyright (C) 2022-2023  Daniel Dwek
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -40,8 +42,8 @@ typedef struct _SchematicView SchematicView;
 
 #include <gtk/gtk.h>
 
-#include "schematic.h"
 #include "sheet.h"
+#include "schematic.h"
 
 /*
  * When stretching a schematic to resize
@@ -83,6 +85,7 @@ void schematic_view_reset_tool (SchematicView *sv);
 void schematic_view_set_browser (SchematicView *sv, gpointer p);
 gpointer schematic_view_get_browser (SchematicView *sv);
 void schematic_view_set_parent (SchematicView *sv, GtkDialog *dialog);
+GtkUIManager *schematic_view_get_ui_manager (SchematicView *sv);
 
 // Logging.
 void schematic_view_log_show (SchematicView *sv, gboolean explicit);

--- a/src/sheet/create-wire.h
+++ b/src/sheet/create-wire.h
@@ -7,12 +7,14 @@
  *  Ricardo Markiewicz <rmarkie@fi.uba.ar>
  *  Andres de Barbara <adebarbara@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
+ *  Daniel Dwek <todovirtual15@gmail.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
  * Copyright (C) 1999-2001  Richard Hult
  * Copyright (C) 2003,2004  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
+ * Copyright (C) 2022-2023  Daniel Dwek
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -34,8 +36,9 @@
 #define __CREATE_WIRE_H
 
 #include <goocanvas.h>
-
+#include "item-data.h"
 #include "sheet.h"
+#include "sheet-item.h"
 #include "wire.h"
 #include "wire-item.h"
 #include "schematic-view.h"

--- a/src/sheet/grid.c
+++ b/src/sheet/grid.c
@@ -175,7 +175,7 @@ Grid *grid_new (GooCanvasItem *root, gdouble width, gdouble height)
 	return grid;
 }
 
-inline gboolean snap_to_grid (Grid *grid, gdouble *x, gdouble *y)
+gboolean snap_to_grid (Grid *grid, gdouble *x, gdouble *y)
 {
 	GridPriv *priv;
 	gdouble spacing;

--- a/src/sheet/node-item.h
+++ b/src/sheet/node-item.h
@@ -8,12 +8,14 @@
  *  Ricardo Markiewicz <rmarkie@fi.uba.ar>
  *  Andres de Barbara <adebarbara@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
+ *  Daniel Dwek <todovirtual15@gmail.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
  * Copyright (C) 1999-2001  Richard Hult
  * Copyright (C) 2003,2004  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
+ * Copyright (C) 2022-2023  Daniel Dwek
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -59,6 +61,6 @@ struct _NodeItemClass
 
 GType node_item_get_type (void);
 GtkWidget *node_item_new (void);
-void node_item_show_dot (NodeItem *item, gboolean show);
+void node_item_show_dots (Sheet *sheet, Coords *pos, gboolean show);
 
 #endif /* __NODE_ITEM_H__ */

--- a/src/sheet/part-item.h
+++ b/src/sheet/part-item.h
@@ -8,6 +8,7 @@
  *  Andres de Barbara <adebarbara@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
  *  Bernhard Schuster <bernhard@ahoi.io>
+ *  Daniel Dwek <todovirtual15@gmail.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
@@ -15,6 +16,7 @@
  * Copyright (C) 2003,2004  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
  * Copyright (C) 2013-2014  Bernhard Schuster
+ * Copyright (C) 2022-2023  Daniel Dwek
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -63,8 +65,10 @@ struct _PartItemClass
 
 GType part_item_get_type (void);
 PartItem *part_item_new (Sheet *sheet, Part *part);
+GooCanvasItem *part_item_canvas_draw (GooCanvasGroup *group, SymbolObject *object);
 void part_item_create_canvas_items_for_preview (GooCanvasGroup *group, LibraryPart *library_part);
 void part_item_update_node_label (PartItem *part);
 void part_item_show_node_labels (PartItem *part, gboolean b);
+void show_labels (SheetItem *sheet_item, gboolean show);
 
 #endif

--- a/src/sheet/rubberband.c
+++ b/src/sheet/rubberband.c
@@ -46,7 +46,7 @@
 
 #include "debug.h"
 
-inline static cairo_pattern_t *create_stipple (const char *color_name, guchar stipple_data[])
+static cairo_pattern_t *create_stipple (const char *color_name, guchar stipple_data[])
 {
 	cairo_surface_t *surface;
 	cairo_pattern_t *pattern;

--- a/src/sheet/sheet-item-factory.c
+++ b/src/sheet/sheet-item-factory.c
@@ -7,12 +7,14 @@
  *  Ricardo Markiewicz <rmarkie@fi.uba.ar>
  *  Andres de Barbara <adebarbara@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
+ *  Daniel Dwek <todovirtual15@gmail.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
  * Copyright (C) 1999-2001  Richard Hult
  * Copyright (C) 2003,2006  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
+ * Copyright (C) 2022-2023  Daniel Dwek
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -30,9 +32,11 @@
  * Boston, MA 02110-1301, USA.
  */
 
+#include "sheet.h"
+#include "sheet-item.h"
 #include "sheet-item-factory.h"
-#include "wire-item.h"
 #include "part-item.h"
+#include "wire-item.h"
 #include "textbox-item.h"
 
 #include "debug.h"
@@ -40,23 +44,21 @@
 // Create a SheetItem from an ItemData object. This is a bit ugly.
 // It could be beautified by having a method that creates the item.
 // E.g. sheet_item->new_from_data (data);
-SheetItem *sheet_item_factory_create_sheet_item (Sheet *sheet, ItemData *data)
+SheetItem *sheet_item_factory_create_sheet_item (Sheet *sheet, ItemData *data, gdouble *ret_points)
 {
-	SheetItem *item;
+	SheetItem *item = NULL;
 
 	g_return_val_if_fail (data != NULL, NULL);
 	g_return_val_if_fail (IS_ITEM_DATA (data), NULL);
 	g_return_val_if_fail (sheet != NULL, NULL);
 	g_return_val_if_fail (IS_SHEET (sheet), NULL);
 
-	item = NULL;
-
 	// Pick the right model.
 	if (IS_PART (data)) {
 		item = SHEET_ITEM (part_item_new (sheet, PART (data)));
 		NG_DEBUG ("part %p", item);
 	} else if (IS_WIRE (data)) {
-		item = SHEET_ITEM (wire_item_new (sheet, WIRE (data)));
+		item = SHEET_ITEM (wire_item_new (sheet, WIRE (data), ret_points));
 		NG_DEBUG ("wire %p", item);
 	} else if (IS_TEXTBOX (data)) {
 		item = SHEET_ITEM (textbox_item_new (sheet, TEXTBOX (data)));

--- a/src/sheet/sheet-item-factory.h
+++ b/src/sheet/sheet-item-factory.h
@@ -7,12 +7,14 @@
  *  Ricardo Markiewicz <rmarkie@fi.uba.ar>
  *  Andres de Barbara <adebarbara@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
+ *  Daniel Dwek <todovirtual15@gmail.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
  * Copyright (C) 1999-2001  Richard Hult
  * Copyright (C) 2003,2004  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
+ * Copyright (C) 2022-2023  Daniel Dwek
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -35,6 +37,6 @@
 
 #include "sheet-item.h"
 
-SheetItem *sheet_item_factory_create_sheet_item (Sheet *sheet, ItemData *data);
+SheetItem *sheet_item_factory_create_sheet_item (Sheet *sheet, ItemData *data, gdouble *ret_points);
 
 #endif /* __SHEET_ITEM_FACTORY_H */

--- a/src/sheet/sheet-item.h
+++ b/src/sheet/sheet-item.h
@@ -45,11 +45,12 @@
 	(G_TYPE_CHECK_CLASS_CAST (klass, sheet_item_get_type (), SheetItemClass))
 #define IS_SHEET_ITEM(obj) (G_TYPE_CHECK_INSTANCE_TYPE (obj, TYPE_SHEET_ITEM))
 
+#include "clipboard.h"
+#include "item-data.h"
+
 typedef struct _SheetItemClass SheetItemClass;
 typedef struct _SheetItemPriv SheetItemPriv;
-
-#include "sheet.h"
-#include "clipboard.h"
+typedef struct _SheetItem SheetItem;
 
 struct _SheetItem
 {
@@ -75,7 +76,7 @@ struct _SheetItemClass
 
 	// Signal handlers.
 	void (*moved)(SheetItem *item);
-	void (*selection_changed)(SheetItem *item);
+	void (*selection_changed)(gpointer *item, gboolean select, gpointer user_data);
 	void (*mouse_over)(SheetItem *item);
 };
 
@@ -99,5 +100,4 @@ void sheet_item_place (SheetItem *item, Sheet *sheet);
 void sheet_item_place_ghost (SheetItem *item, Sheet *sheet);
 void sheet_item_add_menu (SheetItem *item, const char *menu, const GtkActionEntry *action_entries,
                           int nb_entries);
-
 #endif

--- a/src/sheet/sheet.h
+++ b/src/sheet/sheet.h
@@ -8,6 +8,7 @@
  *  Andres de Barbara <adebarbara@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
  *  Guido Trentalancia <guido@trentalancia.com>
+ *  Daniel Dwek <todovirtual15@gmail.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
@@ -15,6 +16,7 @@
  * Copyright (C) 2003,2004  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
  * Copyright (C) 2017       Guido Trentalancia
+ * Copyright (C) 2022-2023  Daniel Dwek
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -38,10 +40,6 @@
 #include <goocanvas.h>
 #include <gtk/gtk.h>
 
-#include "grid.h"
-
-#include "item-data.h"
-
 // typedef to avoid circular dependency
 typedef struct _SchematicView SchematicView;
 
@@ -57,6 +55,9 @@ typedef struct _SheetItem SheetItem;
 #define SHEET(obj) (G_TYPE_CHECK_INSTANCE_CAST (obj, TYPE_SHEET, Sheet))
 #define SHEET_CLASS(klass) (G_TYPE_CHECK_CLASS_CAST (klass, TYPE_SHEET, SheetClass))
 #define IS_SHEET(obj) (G_TYPE_CHECK_INSTANCE_TYPE (obj, TYPE_SHEET))
+
+#include "grid.h"
+#include "stack.h"
 
 typedef enum {
 	SHEET_STATE_NONE,

--- a/src/sheet/wire-item.h
+++ b/src/sheet/wire-item.h
@@ -7,12 +7,14 @@
  *  Ricardo Markiewicz <rmarkie@fi.uba.ar>
  *  Andres de Barbara <adebarbara@fi.uba.ar>
  *  Marc Lorber <lorber.marc@wanadoo.fr>
+ *  Daniel Dwek <todovirtual15@gmail.com>
  *
  * Web page: https://ahoi.io/project/oregano
  *
  * Copyright (C) 1999-2001  Richard Hult
  * Copyright (C) 2003,2004  Ricardo Markiewicz
  * Copyright (C) 2009-2012  Marc Lorber
+ * Copyright (C) 2022-2023  Daniel Dwek
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -35,9 +37,9 @@
 
 #include <gtk/gtk.h>
 
+#include "wire.h"
 #include "sheet.h"
 #include "sheet-item.h"
-#include "wire.h"
 
 #define TYPE_WIRE_ITEM (wire_item_get_type ())
 #define WIRE_ITEM(obj) (G_TYPE_CHECK_INSTANCE_CAST (obj, wire_item_get_type (), WireItem))
@@ -59,7 +61,7 @@ typedef struct
 } WireItemClass;
 
 GType wire_item_get_type (void);
-WireItem *wire_item_new (Sheet *sheet, Wire *wire);
+WireItem *wire_item_new (Sheet *sheet, Wire *wire, gdouble *ret_points);
 void wire_item_initiate (Sheet *sheet);
 void wire_item_get_start_pos (WireItem *item, Coords *pos);
 void wire_item_get_length (WireItem *item, Coords *pos);

--- a/src/stack.c
+++ b/src/stack.c
@@ -1,0 +1,334 @@
+/*
+ * stack.c
+ *
+ *
+ * Authors:
+ *  Daniel Dwek <todovirtual15@gmail.com>
+ *
+ * Web page: https://ahoi.io/project/oregano
+ *
+ * Copyright (C) 2022-2023  Daniel Dwek
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <gtk/gtk.h>
+#include <schematic-view.h>
+#include "debug.h"
+#include "stack.h"
+
+historial_stack_t *undo_stack = NULL;
+historial_stack_t *redo_stack = NULL;
+
+guint stack_get_size (historial_stack_t *stack)
+{
+	return stack->size;
+}
+
+stack_item_t *stack_get_top (historial_stack_t *stack)
+{
+	if (stack->size)
+		return stack->top;
+	else
+		return NULL;
+}
+
+SheetItem *stack_get_sheetitem_by_itemdata (ItemData *data)
+{
+	stack_item_t *iter = NULL;
+
+	if (!data)
+		return NULL;
+
+	for (iter = stack_get_top (undo_stack); iter; iter = iter->prev) {
+		if (sheet_item_get_data (iter->data->s_item) == data)
+			return iter->data->s_item;
+	}
+
+	return NULL;
+}
+
+Coords *stack_get_multiple_group (SheetItem *item, Coords *pos, gint *ret_group)
+{
+	stack_item_t *iter = NULL;
+	Coords *delta = NULL;
+	static Coords prev_delta = { .0 };
+
+	g_return_val_if_fail (item != NULL, NULL);
+	g_return_val_if_fail (ret_group != NULL, NULL);
+
+	delta = g_new0 (Coords, 1);
+	g_assert (delta != NULL);
+
+	for (iter = stack_get_top (undo_stack); iter; iter = iter->prev) {
+		if (iter->data->s_item != item)
+			continue;
+
+		delta->x = pos->x - iter->data->u.moved.coords.x;
+		delta->y = pos->y - iter->data->u.moved.coords.y;
+
+		if (fabs (delta->x - prev_delta.x) < 1e-2 && fabs (delta->y - prev_delta.y) < 1e-2) {
+			*ret_group = stack_get_group (iter->data->s_item, SAME_GROUP);
+		} else {
+			*ret_group = stack_get_group (iter->data->s_item, NEW_GROUP);
+			prev_delta.x = delta->x;
+			prev_delta.y = delta->y;
+		}
+
+		return delta;
+	}
+
+	return NULL;
+}
+
+gint stack_get_group_for_rotation (SheetItem *item, Coords *center, gint angle, Coords *bbox1, Coords *bbox2)
+{
+	gint ret;
+	stack_item_t *iter = NULL;
+	static Coords gcenter = { .0 };
+
+	if (!item || !center)
+		return -1;
+
+	for (iter = stack_get_top (undo_stack); iter; iter = iter->prev) {
+		if (iter->data->type == PART_MOVED || iter->data->type == WIRE_MOVED) {
+			gcenter.x = center->x;
+			gcenter.y = center->y;
+			ret = stack_get_group (item, NEW_GROUP);
+			break;
+		} else if (iter->data->type == PART_ROTATED || iter->data->type == WIRE_ROTATED) {
+			if (fabs (gcenter.x - center->x) < 1e-2 && fabs (gcenter.y - center->y) < 1e-2) {
+				ret = stack_get_group (item, SAME_GROUP);
+				break;
+			} else {
+				gcenter.x = center->x;
+				gcenter.y = center->y;
+				ret = stack_get_group (item, NEW_GROUP);
+				break;
+			}
+		}
+	}
+
+	return ret;
+}
+
+gint stack_get_group (SheetItem *item, group_assignment_t hint)
+{
+	stack_item_t *iter = NULL;
+	static gint group = 0;
+
+	g_return_val_if_fail (item != NULL, 0);
+
+	for (iter = stack_get_top (undo_stack); iter; iter = iter->prev) {
+		if (hint == SAME_GROUP)
+			return group;
+		else if (hint == NEW_GROUP)
+			return ++group;
+	}
+
+	return ++group;
+}
+
+gboolean stack_is_item_registered (stack_data_t *ref)
+{
+	stack_item_t *iter = NULL;
+
+	g_return_val_if_fail (ref != NULL, FALSE);
+
+	for (iter = stack_get_top (undo_stack); iter; iter = iter->prev) {
+		switch (ref->type) {
+		case PART_CREATED:
+		case WIRE_CREATED:
+		case PART_MOVED:
+		case WIRE_MOVED:
+			if (fabs (iter->data->u.moved.coords.x - ref->u.moved.coords.x) < 1e-2 &&
+			    fabs (iter->data->u.moved.coords.y - ref->u.moved.coords.y) < 1e-2)
+				return TRUE;
+			break;
+		case PART_ROTATED:
+		case WIRE_ROTATED:
+			if (iter->data->s_item == ref->s_item && iter->data->u.rotated.angle == ref->u.rotated.angle &&
+			    fabs (iter->data->u.rotated.center.x - ref->u.rotated.center.x) < 1e-2 &&
+			    fabs (iter->data->u.rotated.center.y - ref->u.rotated.center.y) < 1e-2 &&
+			    fabs (iter->data->u.rotated.bbox1.x - ref->u.rotated.bbox1.x) < 1e-2 &&
+			    fabs (iter->data->u.rotated.bbox1.y - ref->u.rotated.bbox1.y) < 1e-2 &&
+			    fabs (iter->data->u.rotated.bbox2.x - ref->u.rotated.bbox2.x) < 1e-2 &&
+			    fabs (iter->data->u.rotated.bbox2.y - ref->u.rotated.bbox2.y) < 1e-2)
+				return TRUE;
+			break;
+		case PART_DELETED:
+		case WIRE_DELETED:
+			if (fabs (iter->data->u.deleted.coords.x - ref->u.deleted.coords.x) < 1e-2 &&
+			    fabs (iter->data->u.deleted.coords.y - ref->u.deleted.coords.y) < 1e-2)
+				return TRUE;
+			break;
+		};
+	}
+
+	return FALSE;
+}
+
+static void stack_set_sensitive (historial_stack_t *stack, SchematicView *sv, gboolean activate)
+{
+	GtkUIManager *ui_mgr = NULL;
+	const gchar *commands[] = { "/MainMenu/MenuEdit/Undo", "/MainMenu/MenuEdit/Redo" };
+
+	if (!stack || !sv)
+		return;
+
+	ui_mgr = schematic_view_get_ui_manager (sv);
+	gtk_action_set_sensitive (gtk_ui_manager_get_action (ui_mgr, (stack == undo_stack) ? commands[0] : commands[1]), activate);
+}
+
+static void stack_debug (historial_stack_t *stack)
+{
+	gint i;
+	stack_item_t *iter = NULL;
+	gchar *str[] = { "PART_CREATED", "PART_MOVED", "PART_ROTATED", "PART_DELETED",
+			 "WIRE_CREATED", "WIRE_MOVED", "WIRE_ROTATED", "WIRE_DELETED" };
+
+	if (stack == undo_stack)
+		fprintf (stderr, "%sUNDO:%s\n", color_orange, color_restore);
+	else
+		fprintf (stderr, "%sREDO:%s\n", color_magenta, color_restore);
+
+	i = stack_get_size (stack) - 1;
+	for (iter = stack_get_top (stack); iter; iter = iter->prev, i--) {
+		fprintf (stderr, "type = %s / group = %d / item = %s%p%s / ", str[iter->data->type],
+			iter->data->group, COLOR_SHEETITEM, iter->data->s_item, COLOR_NORMAL);
+		switch (iter->data->type) {
+		case PART_CREATED:
+			fprintf (stderr, "part created at (%s%f, %f%s)\n", COLOR_COORDS,
+				iter->data->u.moved.coords.x, iter->data->u.moved.coords.y, COLOR_NORMAL);
+			break;
+		case PART_MOVED:
+			fprintf (stderr, "part moved to (%s%f, %f%s) with delta = (%s%f, %f%s)\n", COLOR_COORDS,
+				iter->data->u.moved.coords.x, iter->data->u.moved.coords.y, COLOR_NORMAL,
+				COLOR_COORDS, iter->data->u.moved.delta.x, iter->data->u.moved.delta.y, COLOR_NORMAL);
+			break;
+		case PART_ROTATED:
+			fprintf (stderr, "part rotated %d degrees around (%s%f, %f%s) and bounds (%f, %f) -> (%f, %f)\n",
+				iter->data->u.rotated.angle, COLOR_COORDS,
+				iter->data->u.rotated.center.x, iter->data->u.rotated.center.y, COLOR_NORMAL,
+				iter->data->u.rotated.bbox1.x, iter->data->u.rotated.bbox1.y,
+				iter->data->u.rotated.bbox2.x, iter->data->u.rotated.bbox2.y);
+			break;
+		case PART_DELETED:
+			fprintf (stderr, "part deleted and relocated to (%s%f, %f%s)\n", COLOR_COORDS,
+				iter->data->u.deleted.coords.x, iter->data->u.deleted.coords.y, COLOR_NORMAL);
+			break;
+		case WIRE_CREATED:
+			fprintf (stderr, "wire created at (%s%f, %f%s)\n", COLOR_COORDS,
+				iter->data->u.moved.coords.x, iter->data->u.moved.coords.y, COLOR_NORMAL);
+			break;
+		case WIRE_MOVED:
+			fprintf (stderr, "wire moved to (%s%f, %f%s) with delta = (%s%f, %f%s)\n", COLOR_COORDS,
+				iter->data->u.moved.coords.x, iter->data->u.moved.coords.y, COLOR_NORMAL,
+				COLOR_COORDS, iter->data->u.moved.delta.x, iter->data->u.moved.delta.y, COLOR_NORMAL);
+			break;
+		case WIRE_ROTATED:
+			fprintf (stderr, "wire rotated %d degrees around (%s%f, %f%s)\n",
+				iter->data->u.rotated.angle, COLOR_COORDS,
+				iter->data->u.rotated.center.x, iter->data->u.rotated.center.y, COLOR_NORMAL);
+			break;
+		case WIRE_DELETED:
+			fprintf (stderr, "wire deleted and relocated to (%s%f, %f%s)\n", COLOR_COORDS,
+				iter->data->u.deleted.coords.x, iter->data->u.deleted.coords.y, COLOR_NORMAL);
+			break;
+		};
+	}
+}
+
+gboolean stack_push (historial_stack_t *stack, stack_data_t *data, SchematicView *sv)
+{
+	stack_item_t *top = NULL;
+
+	if (stack && data && sv) {
+		if (stack_is_item_registered (data))
+			return FALSE;
+
+		top = g_new0 (stack_item_t, 1);
+		if (!top)
+			return FALSE;
+
+		if (!stack->size) {
+			stack->top = top;
+			stack->top->prev = NULL;
+		} else {
+			top->prev =stack->top;
+			stack->top = top;
+		}
+
+		stack->top->data = g_new0 (stack_data_t, 1);
+		if (!stack->top->data)
+			return FALSE;
+		stack->top->data = memcpy (stack->top->data, data, sizeof (stack_data_t));
+		stack->size++;
+
+		if (stack_get_size (undo_stack))
+			stack_set_sensitive (undo_stack, sv, TRUE);
+		else
+			stack_set_sensitive (undo_stack, sv, FALSE);
+
+		if (stack_get_size (redo_stack))
+			stack_set_sensitive (redo_stack, sv, TRUE);
+		else
+			stack_set_sensitive (redo_stack, sv, FALSE);
+
+		stack_debug (stack);
+
+		return TRUE;
+	} else {
+		return FALSE;
+	}
+}
+
+stack_data_t **stack_pop (historial_stack_t *stack, gint *ret_nitems)
+{
+	stack_data_t **ret = NULL;
+	gint i = 0, prev_group = -1;
+	stack_item_t *iter = NULL;
+
+	for (iter = stack_get_top (stack); iter; iter = iter->prev) {
+		if (!i)
+			prev_group = iter->data->group;
+		if (iter->data->group == prev_group)
+			i++;
+	}
+
+	if (ret_nitems)
+		*ret_nitems = i;
+
+	ret = g_new0 (stack_data_t *, i);
+	if (!ret)
+		return NULL;
+
+	for (; i > 0; i--) {
+		ret[i - 1] = g_new0 (stack_data_t, 1);
+		ret[i - 1] = memcpy (ret[i - 1], stack->top->data, sizeof (stack_data_t));
+		g_free (stack->top->data);
+		stack->top->data = NULL;
+		stack->top = stack->top->prev;
+		stack->size--;
+	}
+
+	return ret;
+}
+

--- a/src/stack.h
+++ b/src/stack.h
@@ -1,0 +1,87 @@
+/*
+ * stack.h
+ *
+ *
+ * Authors:
+ *  Daniel Dwek <todovirtual15@gmail.com>
+ *
+ * Web page: https://ahoi.io/project/oregano
+ *
+ * Copyright (C) 2022-2023  Daniel Dwek
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __STACK_H
+#define __STACK_H	1
+
+#include "goocanvas.h"
+#include "item-data.h"
+#include "wire-item.h"
+
+typedef enum { PART_CREATED, PART_MOVED, PART_ROTATED, PART_DELETED,
+		WIRE_CREATED, WIRE_MOVED, WIRE_ROTATED, WIRE_DELETED, } item_type_t;
+
+typedef enum { SAME_GROUP, NEW_GROUP } group_assignment_t;
+
+typedef struct stack_data_st {
+	item_type_t type;
+	gint group;
+	SheetItem *s_item;
+	union {
+		struct {
+			Coords coords;
+			Coords delta;
+		} moved;
+		struct {
+			Coords center;
+			gint angle;
+			Coords bbox1;
+			Coords bbox2;
+		} rotated;
+		struct {
+			Coords coords;
+			GooCanvasGroup *canvas_group;
+		} deleted;
+	} u;
+} stack_data_t;
+
+typedef struct stack_item_st {
+	stack_data_t *data;
+	struct stack_item_st *prev;
+} stack_item_t;
+
+typedef struct stack_st {
+	stack_item_t *top;
+	unsigned long long size;
+} historial_stack_t;
+
+extern historial_stack_t *undo_stack;
+extern historial_stack_t *redo_stack;
+
+#include "sheet-item.h"
+#include "load-library.h"
+
+guint stack_get_size (historial_stack_t *stack);
+stack_item_t *stack_get_top (historial_stack_t *stack);
+SheetItem *stack_get_sheetitem_by_itemdata (ItemData *data);
+Coords *stack_get_multiple_group (SheetItem *item, Coords *pos, gint *ret_group);
+gint stack_get_group_for_rotation (SheetItem *item, Coords *center, gint angle, Coords *bbox1, Coords *bbox2);
+gint stack_get_group (SheetItem *item, group_assignment_t hint);
+gboolean stack_is_item_registered (stack_data_t *data);
+gboolean stack_push (historial_stack_t *stack, stack_data_t *data, SchematicView *sv);
+stack_data_t **stack_pop (historial_stack_t *stack, gint *ret_nitems);
+#endif

--- a/test/test.c
+++ b/test/test.c
@@ -12,6 +12,7 @@
 #include "test_update_connection_designators.c"
 #include "test_thread_pipe.c"
 #include "test_engine_ngspice.c"
+#include "test_stack.c"
 
 #if DEBUG_FORCE_FAIL
 void
@@ -30,6 +31,7 @@ main (int argc, char *argv[])
 
 	g_test_init (&argc, &argv, NULL);
 
+	g_test_add_func ("/core/stack", test_stack);
 	g_test_add_func ("/core/coords", test_coords);
 	g_test_add_func ("/core/model/wire/intersection", test_wire_intersection);
 	g_test_add_func ("/core/model/wire/tcrossing", test_wire_tcrossing);

--- a/test/test_nodestore.c
+++ b/test/test_nodestore.c
@@ -2,6 +2,7 @@
 #define TEST_NODESTORE
 
 #include <glib.h>
+#include "stack.h"
 
 void
 test_nodestore ()
@@ -11,11 +12,15 @@ test_nodestore ()
 	Part *part;
 	Wire *wire;
 	Node *node;
+	Coords bbox1, bbox2, center;
 
 	Coords p_pos = {111.,22.};
 	Coords n_pos = {111.,33.};
 	Coords w_pos = {111.,7.};
 	Coords w_len = {0.,88.};
+
+	undo_stack = (historial_stack_t *) calloc (1, sizeof (historial_stack_t));
+	redo_stack = (historial_stack_t *) calloc (1, sizeof (historial_stack_t));
 
 	store = node_store_new ();
 	part = part_new ();
@@ -30,24 +35,26 @@ test_nodestore ()
 	part_set_pins (part, list);
 	g_slist_free (list);
 
-	item_data_set_pos (ITEM_DATA (part), &p_pos);
+	item_data_set_pos (ITEM_DATA (part), &p_pos, EMIT_SIGNAL_CHANGED);
 
-	item_data_set_pos (ITEM_DATA (wire), &w_pos);
+	item_data_set_pos (ITEM_DATA (wire), &w_pos, EMIT_SIGNAL_CHANGED);
 	wire_set_length (wire, &w_len);
 
 	node_store_add_part (store, part);
 	node_store_add_wire (store, wire);
+	item_data_get_absolute_bbox (ITEM_DATA (part), &bbox1, &bbox2);
+	center = coords_average (&bbox1, &bbox2);
 
 	{
 		for (i=0; i<11; i++)
-			item_data_rotate (ITEM_DATA (part), 90, NULL);
-		item_data_set_pos (ITEM_DATA (part), &w_len);
+			item_data_rotate (ITEM_DATA (part), 90, &center, &bbox1, &bbox2, "rotate_items");
+		item_data_set_pos (ITEM_DATA (part), &w_len, EMIT_SIGNAL_CHANGED);
 		for (i=0; i<4; i++)
-			item_data_rotate (ITEM_DATA (part), 90, NULL);
-		item_data_set_pos (ITEM_DATA (part), &n_pos);
+			item_data_rotate (ITEM_DATA (part), 90, &center, &bbox1, &bbox2, "rotate_items");
+		item_data_set_pos (ITEM_DATA (part), &n_pos, EMIT_SIGNAL_CHANGED);
 		for (i=0; i<7; i++)
-			item_data_rotate (ITEM_DATA (part), -90, NULL);
-		item_data_set_pos (ITEM_DATA (part), &p_pos);
+			item_data_rotate (ITEM_DATA (part), -90, &center, &bbox1, &bbox2, "rotate_items");
+		item_data_set_pos (ITEM_DATA (part), &p_pos, EMIT_SIGNAL_CHANGED);
 	}
 	g_assert (node_store_is_wire_at_pos (store, n_pos));
 	g_assert (node_store_is_pin_at_pos (store, n_pos));

--- a/test/test_stack.c
+++ b/test/test_stack.c
@@ -1,0 +1,122 @@
+#ifndef TEST_STACK
+#define TEST_STACK
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "test_stack.h"
+
+historial_stack_t *test_undo_stack = NULL;
+historial_stack_t *test_redo_stack = NULL;
+
+unsigned long long test_stack_get_size (historial_stack_t *stack)
+{
+	return stack->size;
+}
+
+stack_item_t *test_stack_get_top (historial_stack_t *stack)
+{
+	if (stack->size)
+		return stack->top;
+	else
+		return NULL;
+}
+
+gboolean test_stack_push (historial_stack_t *stack, stack_data_t *data)
+{
+	stack_item_t *top = NULL;
+
+	if (stack && data) {
+		top = (stack_item_t *) calloc (1, sizeof (stack_item_t));
+		if (!top)
+			return FALSE;
+
+		if (!stack->size) {
+			stack->top = top;
+			stack->top->prev = NULL;
+		} else {
+			top->prev =stack->top;
+			stack->top = top;
+		}
+
+		stack->top->data = (stack_data_t *) calloc (1, sizeof (stack_data_t));
+		if (!stack->top->data)
+			return FALSE;
+
+		stack->top->data = memcpy (stack->top->data, data, sizeof (stack_data_t));
+		stack->size++;
+		return TRUE;
+	} else {
+		return FALSE;
+	}
+}
+
+stack_data_t *test_stack_pop (historial_stack_t *stack)
+{
+	stack_data_t *ret = NULL;
+
+	if (stack->top) {
+		ret = (stack_data_t *) calloc (1, sizeof (stack_data_t));
+		if (!ret)
+			return NULL;
+
+		ret = memcpy (ret, stack->top->data, sizeof (stack_data_t));
+		free (stack->top->data);
+		stack->top->data = NULL;
+		stack->top =stack->top->prev;
+		stack->size--;
+		return ret;
+	} else {
+		return NULL;
+	}
+}
+
+void test_stack (void)
+{
+	int i;
+	gboolean ret = FALSE;
+	stack_data_t data, *rdata = NULL;
+
+	test_undo_stack = (historial_stack_t *) calloc (1, sizeof (historial_stack_t));
+	if (!test_undo_stack)
+		return;
+
+	test_redo_stack = (historial_stack_t *) calloc (1, sizeof (historial_stack_t));
+	if (!test_redo_stack)
+		return;
+
+	for (i = 0; i < 10; i++) {
+		ret = test_stack_push (test_undo_stack, &data);
+		if (ret)
+			fprintf (stderr, "Pushing item %d onto the UNDO-STACK\n", i);
+	}
+
+	fprintf (stderr, "\n");
+
+	i = test_stack_get_size (test_undo_stack) - 1;
+	while (1) {
+		rdata = test_stack_pop (test_undo_stack);
+		if (!rdata)
+			break;
+
+		fprintf (stderr, "Popping item %d from the UNDO-STACK\n", i);
+		ret = test_stack_push (test_redo_stack, rdata);
+		if (ret)
+			fprintf (stderr, "Pushing item %d onto the REDO-STACK\n", i);
+
+		i--;
+	};
+
+	fprintf (stderr, "\n");
+
+	i = test_stack_get_size (test_redo_stack) - 1;
+	while (1) {
+		rdata = test_stack_pop (test_redo_stack);
+		if (!rdata)
+			break;
+
+		fprintf (stderr, "Popping item %d from the REDO-STACK\n", i);
+		i--;
+	}
+}
+
+#endif

--- a/test/test_stack.h
+++ b/test/test_stack.h
@@ -1,0 +1,13 @@
+#ifndef __TEST_STACK_H
+#define __TEST_STACK_H
+
+#include "sheet-item.h"
+
+extern historial_stack_t *test_undo_stack;
+extern historial_stack_t *test_redo_stack;
+
+unsigned long long test_stack_get_size (historial_stack_t *stack);
+stack_item_t *test_stack_get_top (historial_stack_t *stack);
+gboolean test_stack_push (historial_stack_t *stack, stack_data_t *data);
+stack_data_t *test_stack_pop (historial_stack_t *stack);
+#endif

--- a/test/test_wire.c
+++ b/test/test_wire.c
@@ -43,12 +43,12 @@ test_wire_intersection ()
 	Coords where = {-77777.77,-77.7777};
 	const Coords expected = {50.0,50.0};
 
-	Wire *a = wire_new (NULL);
-	Wire *b = wire_new (NULL);
+	Wire *a = wire_new ();
+	Wire *b = wire_new ();
 
-	item_data_set_pos (ITEM_DATA (a), &p1);
+	item_data_set_pos (ITEM_DATA (a), &p1, EMIT_SIGNAL_CHANGED);
 	wire_set_length (a, &l1);
-	item_data_set_pos (ITEM_DATA (b), &p2);
+	item_data_set_pos (ITEM_DATA (b), &p2, EMIT_SIGNAL_CHANGED);
 	wire_set_length (b, &l2);
 
 	g_assert (do_wires_intersect (a,b,&where));
@@ -72,13 +72,13 @@ test_wire_tcrossing ()
 	Coords where = {-77.77,-77.77};
 	const Coords expected = p1;
 
-	Wire *a = wire_new (NULL);
-	Wire *b = wire_new (NULL);
+	Wire *a = wire_new ();
+	Wire *b = wire_new ();
 
 	{
-		item_data_set_pos (ITEM_DATA (a), &p1);
+		item_data_set_pos (ITEM_DATA (a), &p1, EMIT_SIGNAL_CHANGED);
 		wire_set_length (a, &l1);
-		item_data_set_pos (ITEM_DATA (b), &p2);
+		item_data_set_pos (ITEM_DATA (b), &p2, EMIT_SIGNAL_CHANGED);
 		wire_set_length (b, &l2);
 
 		g_assert (is_t_crossing (a, b, &where));
@@ -86,9 +86,9 @@ test_wire_tcrossing ()
 	}
 
 	{
-		item_data_set_pos (ITEM_DATA (a), &p1);
+		item_data_set_pos (ITEM_DATA (a), &p1, EMIT_SIGNAL_CHANGED);
 		wire_set_length (a, &l2);
-		item_data_set_pos (ITEM_DATA (b), &p2);
+		item_data_set_pos (ITEM_DATA (b), &p2, EMIT_SIGNAL_CHANGED);
 		wire_set_length (b, &l1);
 
 		g_assert (!is_t_crossing (a, b, &where));

--- a/wscript
+++ b/wscript
@@ -85,7 +85,12 @@ def configure(conf):
 
 	# -ggdb vs -g -- http://stackoverflow.com/questions/668962
 	if conf.options.build_debug:
-		conf.env.CFLAGS = ['-ggdb', '-Wall']
+		# We do not want to see so many warnings about deprecated declarations,
+		# especially those ones which do not have recommended functions to replace them.
+		# That's the reason why we include "-Wno-deprecated-declarations" switch below, however,
+		# as software evolutionates, linkage with dependant libraries could be impossible to
+		# achieve without any prior notice from such object files.
+		conf.env.CFLAGS = ['-ggdb', '-Wall', '-Wno-deprecated-declarations']
 		conf.define('DEBUG',1)
 	elif conf.options.build_release:
 		conf.env.CFLAGS = ['-O2', '-Wall']


### PR DESCRIPTION
Hello everyone! A long long time ago I opened an issue about lacking features features such as undo and redo historial to be introduced on this software, but I could not make it real so far.

In fact, here is the solution that all of you expected from me. I'm sorry for having took too long and thank you for your patience.

Back to the point of this commit, you can now make changes like part creation on canvas, parts moved, rotated and deleted ones, as well as you can do the same operations with wires. Operation with textboxes are not currently supported. Everything before mentioned has undo and redo support.

Last but not least, you can watch the .ogv video which will show you the way things work alternating such commands from the toolbar.

Nothing else by now, so... best regards, folks!!!